### PR TITLE
fix: JWT 필터 요청 단위 로그 debug 레벨로 정리 (FOR-104)

### DIFF
--- a/src/main/java/org/forif_backend/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/forif_backend/common/auth/JwtAuthenticationFilter.java
@@ -73,9 +73,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 // 1. Authorization Header에서 JWT 토큰 추출
                 String token = extractTokenFromRequest(request);
 
-                // 2. 토큰이 없으면 다음 필터로 진행
+                // 2. 토큰이 없으면 다음 필터로 진행 (공개 경로 요청마다 발생하는 정상 흐름이므로 debug)
                 if(token == null) {
-                    log.info("토큰이 없습니다. URI: {}", request.getRequestURI());
+                    log.debug("토큰이 없습니다. URI: {}", request.getRequestURI());
                     request.setAttribute("jwt.error", ErrorCode.MISSING_TOKEN);
                     filterChain.doFilter(request, response);
                     return;
@@ -83,7 +83,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // 3. 토큰 만료 여부 확인 (validateToken 전에 먼저 체크)
                 if(jwtProvider.isTokenExpired(token)) {
-                    log.info("토큰이 만료되었습니다. URI: {}", request.getRequestURI());
+                    log.debug("토큰이 만료되었습니다. URI: {}", request.getRequestURI());
                     request.setAttribute("jwt.error", ErrorCode.TOKEN_EXPIRED);
                     filterChain.doFilter(request, response);
                     return;
@@ -115,7 +115,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // 7. 토큰에서 사용자 ID 추출 및 인증 정보 설정
                 setAuthentication(token, request);
-                log.info("JWT 인증 성공. ID: {}", jwtProvider.getUserIdFromToken(token));
+                log.debug("JWT 인증 성공. ID: {}", jwtProvider.getUserIdFromToken(token));
 
             } catch (Exception e) {
                 log.error("JWT 인증 실패: {}", e.getMessage(), e);


### PR DESCRIPTION
## 변경 사항

스터디 개설 신청 unauthorized 신고를 dev 서버 로그로 추적하는 과정에서, 공개 경로 요청마다 `토큰이 없습니다` INFO 로그가 쌓여 실제 인증 오류를 찾기 어려웠음.

- 정상 흐름인 무토큰(공개 경로)·토큰 만료·인증 성공 로그를 INFO → DEBUG로 하향
- 비정상 상황(유효하지 않은 토큰, 블랙리스트 토큰)은 기존 WARN/ERROR 유지

동작 변경 없음 (로그 레벨만). 신고된 unauthorized의 원인은 프론트 세션 처리로 확인되어 프론트 저장소 PR에서 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)