### PR TITLE
fix: 레거시 스터디 멘토 판정 NPE 수정 및 멘토 전용 API 권한 강화 (FOR-104)

### DIFF
--- a/src/main/java/org/forif_backend/domain/study/Study.java
+++ b/src/main/java/org/forif_backend/domain/study/Study.java
@@ -121,7 +121,8 @@ public class Study extends BaseTimeEntity {
      * @return 멘토 여부
      */
     public boolean isMentor(Long userId) {
-        boolean isPrimary = this.primaryMentor.getId().equals(userId);
+        // 레거시 스터디는 멘토가 이름 문자열로만 남아 있고 유저 FK가 없을 수 있다
+        boolean isPrimary = this.primaryMentor != null && this.primaryMentor.getId().equals(userId);
         boolean isSecondary = this.secondaryMentor != null && this.secondaryMentor.getId().equals(userId);
 
         return isPrimary || isSecondary;

--- a/src/main/java/org/forif_backend/web/study/StudyController.java
+++ b/src/main/java/org/forif_backend/web/study/StudyController.java
@@ -137,6 +137,7 @@ public class StudyController {
      * @return 멘토가 개설한 스터디 리스트
      */
     @Operation(summary = "내가 개설한 스터디 조회 (멘토 전용)", description = "로그인한 멘토가 개설한 스터디 목록을 조회합니다.")
+    @PreAuthorize("hasRole('MENTOR')")
     @GetMapping("/api/v1/studies/me/created")
     public ResponseEntity<ApiResponse<List<StudyResponse>>> getMyCreatedStudies(@AuthenticationPrincipal Long userId)
     {

--- a/src/main/java/org/forif_backend/web/userApply/UserApplyController.java
+++ b/src/main/java/org/forif_backend/web/userApply/UserApplyController.java
@@ -15,6 +15,7 @@ import org.forif_backend.domain.user.UserApplyStatus;
 import org.forif_backend.web.userApply.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -52,6 +53,7 @@ public class UserApplyController {
     }
 
     @Operation(summary = "신청자 목록 조회 (멘토 전용)", description = "해당 스터디에 신청한 멘티 목록을 조회합니다. 상태 필터 및 날짜 정렬을 지원합니다.")
+    @PreAuthorize("hasRole('MENTOR')")
     @GetMapping("/{studyId}")
     public ResponseEntity<ApiResponse<PageResponse<UserApplyResponse>>> getUserApply(
                                                                              @AuthenticationPrincipal Long userId,
@@ -67,6 +69,7 @@ public class UserApplyController {
     }
 
     @Operation(summary = "신청서 상세 조회 (멘토 전용)", description = "특정 신청서의 지원 동기 등 상세 내용을 조회합니다.")
+    @PreAuthorize("hasRole('MENTOR')")
     @GetMapping("/{studyId}/{applyId}")
     public ResponseEntity<ApiResponse<UserApplyDetailResponse>> getUserApplyDetail(
                                                                                    @AuthenticationPrincipal Long userId,
@@ -78,6 +81,7 @@ public class UserApplyController {
     }
 
     @Operation(summary = "신청서 상태 변경 (멘토 전용)", description = "신청서의 상태를 PENDING(대기중) 또는 REJECT(탈락)으로 변경합니다. 합격 처리는 /accept 엔드포인트를 사용해주세요.")
+    @PreAuthorize("hasRole('MENTOR')")
     @PatchMapping("/{studyId}/{applyId}/status")
     public ResponseEntity<ApiResponse<Void>> updateApplyStatus(
                                                                 @AuthenticationPrincipal Long userId,
@@ -89,6 +93,7 @@ public class UserApplyController {
     }
 
     @Operation(summary = "합격 처리 (멘토 전용)", description = "신청서 ID 목록을 받아 일괄 합격 처리합니다. 이미 합격인 신청서는 스킵되고, 2순위 합격 상태에서 1순위 합격 시 2순위 StudyUser가 삭제됩니다.")
+    @PreAuthorize("hasRole('MENTOR')")
     @PostMapping("/{studyId}/accept")
     public ResponseEntity<ApiResponse<Void>> acceptApplications(
                                                                  @AuthenticationPrincipal Long userId,
@@ -99,6 +104,7 @@ public class UserApplyController {
     }
 
     @Operation(summary = "불합격 처리 (멘토 전용)", description = "신청서 ID 목록을 받아 일괄 불합격 처리합니다. 이미 불합격인 신청서는 스킵되고, 합격 상태였다면 StudyUser가 삭제됩니다.")
+    @PreAuthorize("hasRole('MENTOR')")
     @PostMapping("/{studyId}/reject")
     public ResponseEntity<ApiResponse<Void>> rejectApplications(
                                                                  @AuthenticationPrincipal Long userId,


### PR DESCRIPTION
## 변경 사항

스터디 관리에서 옛날 개설 스터디 선택 시 신청자 목록 조회(`GET /users/apply/{studyId}`)가 500으로 터지던 문제.

### NPE 수정
- 레거시 스터디는 멘토가 이름 문자열(`primary_mentor_name`)로만 남아 있고 `primary_mentor_id`가 NULL (2019-1~2026-1, 60건 확인)
- `Study.isMentor()`가 `primaryMentor.getId()` 호출 중 NPE → 500
- null-safe로 수정해 멘토 아님(403 NOT_STUDY_MENTOR)으로 정상 응답

### 멘토 전용 API 권한 강화
- 신청자 목록/상세/상태변경/합격/불합격 처리, 내가 개설한 스터디 조회에 `@PreAuthorize("hasRole('MENTOR')")` 추가
- 기존에는 부원(USER) 토큰으로도 소유권만 맞으면 접근 가능했음 — 웹 멘토 탭 로그인(MENTOR role) 전용으로 통일 (ADMIN은 계층 권한으로 계속 접근 가능)
- 프론트도 멘토 세션에서만 스터디 관리 메뉴를 노출하도록 함께 수정 (frontend PR)

테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)