### PR TITLE
feat: 프로덕트 쇼케이스 및 등록 신청 시스템 (FOR-105)

### DIFF
--- a/docs/create-product-tables.sql
+++ b/docs/create-product-tables.sql
@@ -1,0 +1,38 @@
+-- 프로덕트 쇼케이스 테이블 (FOR-105)
+-- local/dev 프로필은 ddl-auto: update 로 자동 생성되므로,
+-- release(validate) 배포 전에만 수동 실행이 필요하다.
+
+CREATE TABLE IF NOT EXISTS tb_product (
+    product_id           INT          NOT NULL AUTO_INCREMENT,
+    slug                 VARCHAR(30)  NOT NULL,
+    name                 VARCHAR(100) NOT NULL,
+    one_liner            VARCHAR(200) NOT NULL,
+    description          TEXT         NULL,
+    status               VARCHAR(20)  NOT NULL,
+    source_type          VARCHAR(20)  NOT NULL,
+    source_label         VARCHAR(100) NULL,
+    tags                 VARCHAR(200) NULL,
+    tech_stack           VARCHAR(300) NULL,
+    service_url          VARCHAR(300) NULL,
+    github_url           VARCHAR(300) NULL,
+    thumbnail_object_key VARCHAR(300) NULL,
+    act_year             INT          NOT NULL,
+    applicant_user_id    BIGINT       NOT NULL,
+    reject_reason        VARCHAR(500) NULL,
+    created_at           DATETIME(6)  NOT NULL,
+    updated_at           DATETIME(6)  NOT NULL,
+    PRIMARY KEY (product_id),
+    UNIQUE KEY uk_product_slug (slug),
+    CONSTRAINT fk_product_applicant FOREIGN KEY (applicant_user_id) REFERENCES tb_user (user_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tb_product_member (
+    product_member_id BIGINT      NOT NULL AUTO_INCREMENT,
+    product_id        INT         NOT NULL,
+    user_name         VARCHAR(50) NOT NULL,
+    role_label        VARCHAR(50) NOT NULL,
+    created_at        DATETIME(6) NOT NULL,
+    updated_at        DATETIME(6) NOT NULL,
+    PRIMARY KEY (product_member_id),
+    CONSTRAINT fk_product_member_product FOREIGN KEY (product_id) REFERENCES tb_product (product_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/java/org/forif_backend/application/product/ProductService.java
+++ b/src/main/java/org/forif_backend/application/product/ProductService.java
@@ -11,6 +11,7 @@ import org.forif_backend.domain.product.ProductRepository;
 import org.forif_backend.domain.product.ProductStatus;
 import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.UserRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +48,9 @@ public class ProductService {
         return ProductInfo.from(product);
     }
 
+    /** 유저당 동시에 검토 대기 상태로 둘 수 있는 신청 수 */
+    private static final int MAX_PENDING_PER_USER = 3;
+
     /** 프로덕트 등록 신청 (부원) */
     @Transactional
     public ProductInfo applyProduct(Long userId, CreateProductApplicationCommand command) {
@@ -55,6 +59,7 @@ public class ProductService {
 
         String slug = command.slug() == null ? "" : command.slug().trim().toLowerCase();
         validateSlug(slug);
+        validatePendingLimit(userId);
 
         Product product = Product.createPending(
                 slug,
@@ -62,16 +67,21 @@ public class ProductService {
                 command.oneLiner().trim(),
                 command.description().trim(),
                 command.sourceType(),
-                joinCsv(command.tags()),
-                joinCsv(command.techStack()),
-                blankToNull(command.serviceUrl()),
-                blankToNull(command.githubUrl()),
+                joinCsv(command.tags(), 200),
+                joinCsv(command.techStack(), 300),
+                requireHttpUrl(command.serviceUrl()),
+                requireHttpUrl(command.githubUrl()),
                 LocalDate.now().getYear(),
                 applicant
         );
         product.addMember(ProductMember.create(product, applicant.getUserName(), "신청자"));
 
-        return ProductInfo.from(productRepository.save(product));
+        try {
+            return ProductInfo.from(productRepository.save(product));
+        } catch (DataIntegrityViolationException e) {
+            // slug 중복 검사와 저장 사이의 경합 — UNIQUE 제약이 최종 방어선
+            throw new ForifException(ErrorCode.PRODUCT_SLUG_ALREADY_EXISTS);
+        }
     }
 
     /** 내 신청 현황 (부원) */
@@ -125,16 +135,38 @@ public class ProductService {
         }
     }
 
-    private String joinCsv(List<String> values) {
+    private void validatePendingLimit(Long userId) {
+        long pendingCount = productRepository.findAllByApplicantId(userId).stream()
+                .filter(p -> p.getStatus() == ProductStatus.PENDING)
+                .count();
+        if (pendingCount >= MAX_PENDING_PER_USER) {
+            throw new ForifException(ErrorCode.PRODUCT_PENDING_LIMIT);
+        }
+    }
+
+    private String joinCsv(List<String> values, int maxLength) {
         if (values == null) return null;
         List<String> cleaned = values.stream()
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .toList();
-        return cleaned.isEmpty() ? null : String.join(",", cleaned);
+        if (cleaned.isEmpty()) return null;
+
+        String joined = String.join(",", cleaned);
+        if (joined.length() > maxLength) {
+            throw new ForifException(ErrorCode.PRODUCT_INPUT_TOO_LONG);
+        }
+        return joined;
     }
 
-    private String blankToNull(String value) {
-        return (value == null || value.isBlank()) ? null : value.trim();
+    /** 링크로 렌더링되는 값이므로 http(s) 스킴만 허용한다 (javascript: 등 주입 방지) */
+    private String requireHttpUrl(String value) {
+        if (value == null || value.isBlank()) return null;
+        String trimmed = value.trim();
+        String lower = trimmed.toLowerCase();
+        if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
+            throw new ForifException(ErrorCode.PRODUCT_URL_INVALID);
+        }
+        return trimmed;
     }
 }

--- a/src/main/java/org/forif_backend/application/product/ProductService.java
+++ b/src/main/java/org/forif_backend/application/product/ProductService.java
@@ -1,0 +1,140 @@
+package org.forif_backend.application.product;
+
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.application.product.dto.CreateProductApplicationCommand;
+import org.forif_backend.application.product.dto.ProductInfo;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.product.Product;
+import org.forif_backend.domain.product.ProductMember;
+import org.forif_backend.domain.product.ProductRepository;
+import org.forif_backend.domain.product.ProductStatus;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductService {
+
+    private static final Pattern SLUG_PATTERN = Pattern.compile("^[a-z0-9](?:[a-z0-9-]{1,18})[a-z0-9]$");
+    private static final Set<String> RESERVED_SLUGS = Set.of(
+            "www", "dev", "api", "admin", "mail", "apply", "applications", "products", "forif"
+    );
+
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    /** 게시된 프로덕트 목록 (공개) */
+    public List<ProductInfo> getPublishedProducts() {
+        return productRepository.findAllPublished().stream()
+                .map(ProductInfo::from)
+                .toList();
+    }
+
+    /** 게시된 프로덕트 상세 (공개) */
+    public ProductInfo getPublishedProduct(String slug) {
+        Product product = productRepository.findBySlug(slug)
+                .filter(p -> p.getStatus().isPublished())
+                .orElseThrow(() -> new ForifException(ErrorCode.PRODUCT_NOT_FOUND));
+        return ProductInfo.from(product);
+    }
+
+    /** 프로덕트 등록 신청 (부원) */
+    @Transactional
+    public ProductInfo applyProduct(Long userId, CreateProductApplicationCommand command) {
+        User applicant = userRepository.findUserById(userId)
+                .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
+
+        String slug = command.slug() == null ? "" : command.slug().trim().toLowerCase();
+        validateSlug(slug);
+
+        Product product = Product.createPending(
+                slug,
+                command.name().trim(),
+                command.oneLiner().trim(),
+                command.description().trim(),
+                command.sourceType(),
+                joinCsv(command.tags()),
+                joinCsv(command.techStack()),
+                blankToNull(command.serviceUrl()),
+                blankToNull(command.githubUrl()),
+                LocalDate.now().getYear(),
+                applicant
+        );
+        product.addMember(ProductMember.create(product, applicant.getUserName(), "신청자"));
+
+        return ProductInfo.from(productRepository.save(product));
+    }
+
+    /** 내 신청 현황 (부원) */
+    public List<ProductInfo> getMyApplications(Long userId) {
+        return productRepository.findAllByApplicantId(userId).stream()
+                .map(ProductInfo::from)
+                .toList();
+    }
+
+    // ── 운영진 ──────────────────────────────────────────────────────
+
+    public List<ProductInfo> getAllProducts() {
+        return productRepository.findAll().stream()
+                .map(ProductInfo::from)
+                .toList();
+    }
+
+    @Transactional
+    public void approveProduct(Integer productId) {
+        getProductById(productId).approve();
+    }
+
+    @Transactional
+    public void rejectProduct(Integer productId, String reason) {
+        getProductById(productId).reject(reason);
+    }
+
+    @Transactional
+    public void changeProductStatus(Integer productId, ProductStatus status) {
+        getProductById(productId).changeStatus(status);
+    }
+
+    @Transactional
+    public void deleteProduct(Integer productId) {
+        productRepository.delete(getProductById(productId));
+    }
+
+    // ── 내부 유틸 ────────────────────────────────────────────────────
+
+    private Product getProductById(Integer productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new ForifException(ErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    private void validateSlug(String slug) {
+        if (!SLUG_PATTERN.matcher(slug).matches() || RESERVED_SLUGS.contains(slug)) {
+            throw new ForifException(ErrorCode.PRODUCT_SLUG_INVALID);
+        }
+        if (productRepository.existsBySlug(slug)) {
+            throw new ForifException(ErrorCode.PRODUCT_SLUG_ALREADY_EXISTS);
+        }
+    }
+
+    private String joinCsv(List<String> values) {
+        if (values == null) return null;
+        List<String> cleaned = values.stream()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        return cleaned.isEmpty() ? null : String.join(",", cleaned);
+    }
+
+    private String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value.trim();
+    }
+}

--- a/src/main/java/org/forif_backend/application/product/dto/CreateProductApplicationCommand.java
+++ b/src/main/java/org/forif_backend/application/product/dto/CreateProductApplicationCommand.java
@@ -1,0 +1,18 @@
+package org.forif_backend.application.product.dto;
+
+import org.forif_backend.domain.product.ProductSourceType;
+
+import java.util.List;
+
+public record CreateProductApplicationCommand(
+        String name,
+        String slug,
+        String oneLiner,
+        String description,
+        ProductSourceType sourceType,
+        String serviceUrl,
+        String githubUrl,
+        List<String> techStack,
+        List<String> tags
+) {
+}

--- a/src/main/java/org/forif_backend/application/product/dto/ProductInfo.java
+++ b/src/main/java/org/forif_backend/application/product/dto/ProductInfo.java
@@ -1,0 +1,73 @@
+package org.forif_backend.application.product.dto;
+
+import lombok.Builder;
+import org.forif_backend.domain.product.Product;
+import org.forif_backend.domain.product.ProductMember;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
+@Builder
+public record ProductInfo(
+        Integer productId,
+        String slug,
+        String name,
+        String oneLiner,
+        String description,
+        String status,
+        String sourceType,
+        String sourceLabel,
+        List<String> tags,
+        List<String> techStack,
+        String serviceUrl,
+        String githubUrl,
+        int actYear,
+        String rejectReason,
+        String appliedAt,
+        String applicantName,
+        Long applicantId,
+        List<MemberInfo> members
+) {
+
+    public record MemberInfo(String userName, String roleLabel) {
+        public static MemberInfo from(ProductMember member) {
+            return new MemberInfo(member.getUserName(), member.getRoleLabel());
+        }
+    }
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public static ProductInfo from(Product product) {
+        return ProductInfo.builder()
+                .productId(product.getId())
+                .slug(product.getSlug())
+                .name(product.getName())
+                .oneLiner(product.getOneLiner())
+                .description(product.getDescription())
+                .status(product.getStatus().name())
+                .sourceType(product.getSourceType().name())
+                .sourceLabel(product.getSourceLabel())
+                .tags(splitCsv(product.getTags()))
+                .techStack(splitCsv(product.getTechStack()))
+                .serviceUrl(product.getServiceUrl())
+                .githubUrl(product.getGithubUrl())
+                .actYear(product.getActYear())
+                .rejectReason(product.getRejectReason())
+                .appliedAt(product.getCreatedAt() != null
+                        ? product.getCreatedAt().format(DATE_FORMAT)
+                        : null)
+                .applicantName(product.getApplicant().getUserName())
+                .applicantId(product.getApplicant().getId())
+                .members(product.getMembers().stream().map(MemberInfo::from).toList())
+                .build();
+    }
+
+    private static List<String> splitCsv(String value) {
+        if (value == null || value.isBlank()) return List.of();
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/src/main/java/org/forif_backend/common/config/SecurityConfig.java
+++ b/src/main/java/org/forif_backend/common/config/SecurityConfig.java
@@ -61,6 +61,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET,
                     "/api/v1/studies",
                     "/api/v1/studies/{studyId}",
+                    "/api/v1/products",
+                    "/api/v1/products/{slug}",
                     "/api/v1/hackathons",
                     "/api/v1/hackathons/{hackathonId}",
                     "/api/v1/hackathons/{hackathonId}/submissions/**",

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -95,6 +95,13 @@ public enum ErrorCode {
     HACKATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR074-409", "이미 등록된 해커톤입니다."),
     HACKATHON_ACTIVE_EVENT_EXISTS(HttpStatus.CONFLICT, "FOR076-409", "진행 중인 해커톤이 있어 새 해커톤을 생성할 수 없습니다."),
 
+    // Product (프로덕트 쇼케이스)
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR110-404", "해당 프로덕트를 찾을 수 없습니다."),
+    PRODUCT_SLUG_INVALID(HttpStatus.BAD_REQUEST, "FOR111-400", "서브도메인은 영소문자·숫자·하이픈 3~20자여야 합니다."),
+    PRODUCT_SLUG_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR112-409", "이미 사용 중인 서브도메인입니다."),
+    PRODUCT_NOT_PENDING(HttpStatus.BAD_REQUEST, "FOR113-400", "검토 대기 상태의 신청만 처리할 수 있습니다."),
+    PRODUCT_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR114-400", "게시된 프로덕트의 상태만 변경할 수 있습니다."),
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FOR100-500", "서버 내부 오류가 발생했습니다."),
     INVALID_STATUS_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, "FOR101-500", "유효하지 않은 상태 값입니다."),

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -101,6 +101,9 @@ public enum ErrorCode {
     PRODUCT_SLUG_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR112-409", "이미 사용 중인 서브도메인입니다."),
     PRODUCT_NOT_PENDING(HttpStatus.BAD_REQUEST, "FOR113-400", "검토 대기 상태의 신청만 처리할 수 있습니다."),
     PRODUCT_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR114-400", "게시된 프로덕트의 상태만 변경할 수 있습니다."),
+    PRODUCT_URL_INVALID(HttpStatus.BAD_REQUEST, "FOR115-400", "URL은 http:// 또는 https:// 로 시작해야 합니다."),
+    PRODUCT_PENDING_LIMIT(HttpStatus.BAD_REQUEST, "FOR116-400", "검토 대기 중인 신청이 너무 많습니다. 검토 완료 후 다시 신청해주세요."),
+    PRODUCT_INPUT_TOO_LONG(HttpStatus.BAD_REQUEST, "FOR117-400", "태그 또는 기술 스택이 너무 깁니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FOR100-500", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/org/forif_backend/domain/product/Product.java
+++ b/src/main/java/org/forif_backend/domain/product/Product.java
@@ -1,0 +1,135 @@
+package org.forif_backend.domain.product;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.forif_backend.common.BaseTimeEntity;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.user.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 부원이 만든 프로덕트(서비스).
+ * 등록 신청(PENDING/REJECTED)과 승인 후 게시(LIVE/DEV/PAUSED/RETIRED)를 하나의 엔티티로 관리한다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_product")
+public class Product extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private Integer id;
+
+    /** 서브도메인으로 쓰이는 식별자 ({slug}.forif.org) */
+    @Column(nullable = false, unique = true, length = 30)
+    private String slug;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "one_liner", nullable = false, length = 200)
+    private String oneLiner;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ProductStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 20)
+    private ProductSourceType sourceType;
+
+    /** 출처 표기 라벨 (예: "2026-1 해커톤 대상") */
+    @Column(name = "source_label", length = 100)
+    private String sourceLabel;
+
+    /** 쉼표로 구분된 태그 목록 */
+    @Column(length = 200)
+    private String tags;
+
+    /** 쉼표로 구분된 기술 스택 목록 */
+    @Column(name = "tech_stack", length = 300)
+    private String techStack;
+
+    @Column(name = "service_url", length = 300)
+    private String serviceUrl;
+
+    @Column(name = "github_url", length = 300)
+    private String githubUrl;
+
+    @Column(name = "thumbnail_object_key", length = 300)
+    private String thumbnailObjectKey;
+
+    @Column(name = "act_year", nullable = false)
+    private int actYear;
+
+    /** 등록을 신청한 부원 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_user_id", nullable = false)
+    private User applicant;
+
+    @Column(name = "reject_reason", length = 500)
+    private String rejectReason;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductMember> members = new ArrayList<>();
+
+    public static Product createPending(String slug, String name, String oneLiner, String description,
+                                        ProductSourceType sourceType, String tags, String techStack,
+                                        String serviceUrl, String githubUrl, int actYear, User applicant) {
+        Product product = new Product();
+        product.slug = slug;
+        product.name = name;
+        product.oneLiner = oneLiner;
+        product.description = description;
+        product.status = ProductStatus.PENDING;
+        product.sourceType = sourceType;
+        product.tags = tags;
+        product.techStack = techStack;
+        product.serviceUrl = serviceUrl;
+        product.githubUrl = githubUrl;
+        product.actYear = actYear;
+        product.applicant = applicant;
+        return product;
+    }
+
+    public void addMember(ProductMember member) {
+        members.add(member);
+    }
+
+    public void approve() {
+        if (status != ProductStatus.PENDING) {
+            throw new ForifException(ErrorCode.PRODUCT_NOT_PENDING);
+        }
+        this.status = ProductStatus.LIVE;
+        this.rejectReason = null;
+    }
+
+    public void reject(String reason) {
+        if (status != ProductStatus.PENDING) {
+            throw new ForifException(ErrorCode.PRODUCT_NOT_PENDING);
+        }
+        this.status = ProductStatus.REJECTED;
+        this.rejectReason = reason;
+    }
+
+    public void changeStatus(ProductStatus newStatus) {
+        if (!this.status.isPublished() || !newStatus.isPublished()) {
+            throw new ForifException(ErrorCode.PRODUCT_STATUS_NOT_CHANGEABLE);
+        }
+        this.status = newStatus;
+    }
+
+    public void updateSourceLabel(String sourceLabel) {
+        this.sourceLabel = sourceLabel;
+    }
+}

--- a/src/main/java/org/forif_backend/domain/product/ProductMember.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductMember.java
@@ -1,0 +1,42 @@
+package org.forif_backend.domain.product;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.forif_backend.common.BaseTimeEntity;
+
+/**
+ * 프로덕트 팀원.
+ * 졸업생 등 비가입자도 있을 수 있어 유저 FK 대신 이름을 직접 보관한다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_product_member")
+public class ProductMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "user_name", nullable = false, length = 50)
+    private String userName;
+
+    /** 역할 표기 (예: "팀장 · 백엔드") */
+    @Column(name = "role_label", nullable = false, length = 50)
+    private String roleLabel;
+
+    public static ProductMember create(Product product, String userName, String roleLabel) {
+        ProductMember member = new ProductMember();
+        member.product = product;
+        member.userName = userName;
+        member.roleLabel = roleLabel;
+        return member;
+    }
+}

--- a/src/main/java/org/forif_backend/domain/product/ProductRepository.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductRepository.java
@@ -1,0 +1,26 @@
+package org.forif_backend.domain.product;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductRepository {
+
+    Product save(Product product);
+
+    Optional<Product> findById(Integer productId);
+
+    Optional<Product> findBySlug(String slug);
+
+    boolean existsBySlug(String slug);
+
+    /** 게시된(승인 이후) 프로덕트 목록 — 최신 연도순 */
+    List<Product> findAllPublished();
+
+    /** 신청자 기준 전체 신청/게시 목록 — 최신 신청순 */
+    List<Product> findAllByApplicantId(Long userId);
+
+    /** 어드민용 전체 목록 (상태 무관) — 최신 신청순 */
+    List<Product> findAll();
+
+    void delete(Product product);
+}

--- a/src/main/java/org/forif_backend/domain/product/ProductSourceType.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductSourceType.java
@@ -1,0 +1,8 @@
+package org.forif_backend.domain.product;
+
+/** 프로덕트 출처 (스터디 / 해커톤 / 자율 프로젝트) */
+public enum ProductSourceType {
+    STUDY,
+    HACKATHON,
+    SIDE
+}

--- a/src/main/java/org/forif_backend/domain/product/ProductStatus.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductStatus.java
@@ -1,0 +1,18 @@
+package org.forif_backend.domain.product;
+
+/**
+ * 프로덕트 상태.
+ * PENDING/REJECTED 는 등록 신청 단계, 나머지는 승인 후 게시 상태를 나타낸다.
+ */
+public enum ProductStatus {
+    PENDING,    // 검토 대기
+    REJECTED,   // 반려
+    LIVE,       // 서비스 중
+    DEV,        // 개발 중
+    PAUSED,     // 운영 중단
+    RETIRED;    // 서비스 종료
+
+    public boolean isPublished() {
+        return this == LIVE || this == DEV || this == PAUSED || this == RETIRED;
+    }
+}

--- a/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductJpaRepository.java
@@ -1,0 +1,31 @@
+package org.forif_backend.infrastructure.persistence.product;
+
+import org.forif_backend.domain.product.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductJpaRepository extends JpaRepository<Product, Integer> {
+
+    Optional<Product> findBySlug(String slug);
+
+    boolean existsBySlug(String slug);
+
+    @Query("""
+            SELECT p FROM Product p
+            WHERE p.status IN (org.forif_backend.domain.product.ProductStatus.LIVE,
+                               org.forif_backend.domain.product.ProductStatus.DEV,
+                               org.forif_backend.domain.product.ProductStatus.PAUSED,
+                               org.forif_backend.domain.product.ProductStatus.RETIRED)
+            ORDER BY p.actYear DESC, p.id DESC
+            """)
+    List<Product> findAllPublished();
+
+    @Query("SELECT p FROM Product p WHERE p.applicant.id = :userId ORDER BY p.id DESC")
+    List<Product> findAllByApplicantId(@Param("userId") Long userId);
+
+    List<Product> findAllByOrderByIdDesc();
+}

--- a/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductRepositoryImpl.java
@@ -1,0 +1,56 @@
+package org.forif_backend.infrastructure.persistence.product;
+
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.domain.product.Product;
+import org.forif_backend.domain.product.ProductRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+
+    @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
+
+    @Override
+    public Optional<Product> findById(Integer productId) {
+        return productJpaRepository.findById(productId);
+    }
+
+    @Override
+    public Optional<Product> findBySlug(String slug) {
+        return productJpaRepository.findBySlug(slug);
+    }
+
+    @Override
+    public boolean existsBySlug(String slug) {
+        return productJpaRepository.existsBySlug(slug);
+    }
+
+    @Override
+    public List<Product> findAllPublished() {
+        return productJpaRepository.findAllPublished();
+    }
+
+    @Override
+    public List<Product> findAllByApplicantId(Long userId) {
+        return productJpaRepository.findAllByApplicantId(userId);
+    }
+
+    @Override
+    public List<Product> findAll() {
+        return productJpaRepository.findAllByOrderByIdDesc();
+    }
+
+    @Override
+    public void delete(Product product) {
+        productJpaRepository.delete(product);
+    }
+}

--- a/src/main/java/org/forif_backend/web/product/AdminProductController.java
+++ b/src/main/java/org/forif_backend/web/product/AdminProductController.java
@@ -1,0 +1,94 @@
+package org.forif_backend.web.product;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.application.product.ProductService;
+import org.forif_backend.common.dto.response.ApiResponse;
+import org.forif_backend.domain.product.ProductStatus;
+import org.forif_backend.web.product.dto.AdminProductResponse;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "프로덕트 관리 (운영진)", description = "프로덕트 등록 신청 검토 및 게시 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/products")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminProductController {
+
+    private final ProductService productService;
+
+    @Operation(summary = "프로덕트 전체 목록 (운영진)", description = "검토 대기 신청을 포함한 모든 프로덕트를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminProductResponse>>> getAllProducts() {
+        return ResponseEntity.ok(
+                ApiResponse.success(AdminProductResponse.fromList(productService.getAllProducts())));
+    }
+
+    @Operation(summary = "등록 신청 승인", description = "검토 대기 신청을 승인해 서비스 중 상태로 게시합니다.")
+    @PatchMapping("/{productId}/approve")
+    public ResponseEntity<ApiResponse<Void>> approveProduct(
+            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId
+    ) {
+        productService.approveProduct(productId);
+        return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
+    }
+
+    @Operation(summary = "등록 신청 반려", description = "검토 대기 신청을 사유와 함께 반려합니다.")
+    @PatchMapping("/{productId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectProduct(
+            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @Valid @RequestBody RejectProductRequest request
+    ) {
+        productService.rejectProduct(productId, request.getRejectReason());
+        return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
+    }
+
+    @Operation(summary = "게시 상태 변경", description = "게시된 프로덕트의 상태(LIVE/DEV/PAUSED/RETIRED)를 변경합니다.")
+    @PatchMapping("/{productId}/status")
+    public ResponseEntity<ApiResponse<Void>> changeProductStatus(
+            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @Valid @RequestBody UpdateProductStatusRequest request
+    ) {
+        productService.changeProductStatus(productId, request.getStatus());
+        return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
+    }
+
+    @Operation(summary = "프로덕트 삭제", description = "프로덕트(신청 포함)를 삭제합니다.")
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ApiResponse<Void>> deleteProduct(
+            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId
+    ) {
+        productService.deleteProduct(productId);
+        return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class RejectProductRequest {
+        @NotBlank
+        @Length(max = 500)
+        private String rejectReason;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class UpdateProductStatusRequest {
+        @NotNull
+        private ProductStatus status;
+    }
+}

--- a/src/main/java/org/forif_backend/web/product/ProductController.java
+++ b/src/main/java/org/forif_backend/web/product/ProductController.java
@@ -1,0 +1,63 @@
+package org.forif_backend.web.product;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.application.product.ProductService;
+import org.forif_backend.application.product.dto.ProductInfo;
+import org.forif_backend.common.dto.response.ApiResponse;
+import org.forif_backend.web.product.dto.CreateProductApplicationRequest;
+import org.forif_backend.web.product.dto.ProductApplicationResponse;
+import org.forif_backend.web.product.dto.ProductDetailResponse;
+import org.forif_backend.web.product.dto.ProductResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "프로덕트", description = "부원 프로덕트 쇼케이스 및 등록 신청 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+public class ProductController {
+
+    private final ProductService productService;
+
+    @Operation(summary = "프로덕트 목록 조회", description = "게시된(승인된) 프로덕트 목록을 조회합니다. 인증 없이 접근 가능합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ProductResponse>>> getProducts() {
+        List<ProductInfo> products = productService.getPublishedProducts();
+        return ResponseEntity.ok(ApiResponse.success(ProductResponse.fromList(products)));
+    }
+
+    @Operation(summary = "내 프로덕트 신청 현황", description = "로그인한 부원의 프로덕트 등록 신청 목록과 검토 결과를 조회합니다.")
+    @GetMapping("/applications/me")
+    public ResponseEntity<ApiResponse<List<ProductApplicationResponse>>> getMyApplications(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<ProductInfo> applications = productService.getMyApplications(userId);
+        return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.fromList(applications)));
+    }
+
+    @Operation(summary = "프로덕트 등록 신청", description = "부원이 직접 만든 서비스의 등록을 신청합니다. 운영진 승인 후 목록에 게시됩니다.")
+    @PostMapping("/applications")
+    public ResponseEntity<ApiResponse<ProductApplicationResponse>> applyProduct(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody CreateProductApplicationRequest request
+    ) {
+        ProductInfo info = productService.applyProduct(userId, request.toCommand());
+        return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.from(info)));
+    }
+
+    @Operation(summary = "프로덕트 상세 조회", description = "게시된 프로덕트의 상세 정보를 조회합니다. 인증 없이 접근 가능합니다.")
+    @GetMapping("/{slug}")
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
+            @Parameter(description = "프로덕트 슬러그(서브도메인)") @PathVariable String slug
+    ) {
+        ProductInfo product = productService.getPublishedProduct(slug);
+        return ResponseEntity.ok(ApiResponse.success(ProductDetailResponse.from(product)));
+    }
+}

--- a/src/main/java/org/forif_backend/web/product/dto/AdminProductResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/AdminProductResponse.java
@@ -1,0 +1,53 @@
+package org.forif_backend.web.product.dto;
+
+import lombok.Builder;
+import org.forif_backend.application.product.dto.ProductInfo;
+
+import java.util.List;
+
+@Builder
+public record AdminProductResponse(
+        Integer productId,
+        String slug,
+        String name,
+        String oneLiner,
+        String description,
+        String status,
+        String sourceType,
+        String sourceLabel,
+        List<String> tags,
+        List<String> techStack,
+        String serviceUrl,
+        String githubUrl,
+        int actYear,
+        String rejectReason,
+        String appliedAt,
+        String applicantName,
+        Long applicantId
+) {
+    public static AdminProductResponse from(ProductInfo info) {
+        return AdminProductResponse.builder()
+                .productId(info.productId())
+                .slug(info.slug())
+                .name(info.name())
+                .oneLiner(info.oneLiner())
+                .description(info.description())
+                .status(info.status())
+                .sourceType(info.sourceType())
+                .sourceLabel(info.sourceLabel())
+                .tags(info.tags())
+                .techStack(info.techStack())
+                .serviceUrl(info.serviceUrl())
+                .githubUrl(info.githubUrl())
+                .actYear(info.actYear())
+                .rejectReason(info.rejectReason())
+                .appliedAt(info.appliedAt())
+                .applicantName(info.applicantName())
+                .applicantId(info.applicantId())
+                .build();
+    }
+
+    public static List<AdminProductResponse> fromList(List<ProductInfo> infos) {
+        return infos.stream().map(AdminProductResponse::from).toList();
+    }
+}

--- a/src/main/java/org/forif_backend/web/product/dto/CreateProductApplicationRequest.java
+++ b/src/main/java/org/forif_backend/web/product/dto/CreateProductApplicationRequest.java
@@ -2,6 +2,7 @@ package org.forif_backend.web.product.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -29,6 +30,7 @@ public class CreateProductApplicationRequest {
     private String oneLiner;
 
     @NotBlank
+    @Length(max = 2000, message = "상세 소개는 2000자 이내로 작성해주세요.")
     private String description;
 
     @NotNull
@@ -40,8 +42,10 @@ public class CreateProductApplicationRequest {
     @Length(max = 300)
     private String githubUrl;
 
+    @Size(max = 10)
     private List<String> techStack;
 
+    @Size(max = 10)
     private List<String> tags;
 
     public CreateProductApplicationCommand toCommand() {

--- a/src/main/java/org/forif_backend/web/product/dto/CreateProductApplicationRequest.java
+++ b/src/main/java/org/forif_backend/web/product/dto/CreateProductApplicationRequest.java
@@ -1,0 +1,53 @@
+package org.forif_backend.web.product.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.forif_backend.application.product.dto.CreateProductApplicationCommand;
+import org.forif_backend.domain.product.ProductSourceType;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateProductApplicationRequest {
+
+    @NotBlank
+    @Length(max = 100)
+    private String name;
+
+    @NotBlank
+    @Length(max = 30)
+    private String slug;
+
+    @NotBlank
+    @Length(max = 200)
+    private String oneLiner;
+
+    @NotBlank
+    private String description;
+
+    @NotNull
+    private ProductSourceType sourceType;
+
+    @Length(max = 300)
+    private String serviceUrl;
+
+    @Length(max = 300)
+    private String githubUrl;
+
+    private List<String> techStack;
+
+    private List<String> tags;
+
+    public CreateProductApplicationCommand toCommand() {
+        return new CreateProductApplicationCommand(
+                name, slug, oneLiner, description, sourceType,
+                serviceUrl, githubUrl, techStack, tags
+        );
+    }
+}

--- a/src/main/java/org/forif_backend/web/product/dto/ProductApplicationResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/ProductApplicationResponse.java
@@ -1,0 +1,52 @@
+package org.forif_backend.web.product.dto;
+
+import lombok.Builder;
+import org.forif_backend.application.product.dto.ProductInfo;
+
+import java.util.List;
+
+@Builder
+public record ProductApplicationResponse(
+        Integer applicationId,
+        String name,
+        String slug,
+        String oneLiner,
+        String description,
+        String sourceType,
+        String serviceUrl,
+        String githubUrl,
+        List<String> techStack,
+        String status,
+        String rejectReason,
+        String appliedAt
+) {
+    public static ProductApplicationResponse from(ProductInfo info) {
+        return ProductApplicationResponse.builder()
+                .applicationId(info.productId())
+                .name(info.name())
+                .slug(info.slug())
+                .oneLiner(info.oneLiner())
+                .description(info.description())
+                .sourceType(info.sourceType())
+                .serviceUrl(info.serviceUrl())
+                .githubUrl(info.githubUrl())
+                .techStack(info.techStack())
+                .status(toApplicationStatus(info.status()))
+                .rejectReason(info.rejectReason())
+                .appliedAt(info.appliedAt())
+                .build();
+    }
+
+    public static List<ProductApplicationResponse> fromList(List<ProductInfo> infos) {
+        return infos.stream().map(ProductApplicationResponse::from).toList();
+    }
+
+    /** 게시 상태(LIVE/DEV/...)는 신청자 관점에서 모두 "승인"으로 표기 */
+    private static String toApplicationStatus(String status) {
+        return switch (status) {
+            case "PENDING" -> "PENDING";
+            case "REJECTED" -> "REJECTED";
+            default -> "APPROVED";
+        };
+    }
+}

--- a/src/main/java/org/forif_backend/web/product/dto/ProductDetailResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/ProductDetailResponse.java
@@ -1,0 +1,50 @@
+package org.forif_backend.web.product.dto;
+
+import lombok.Builder;
+import org.forif_backend.application.product.dto.ProductInfo;
+
+import java.util.List;
+
+@Builder
+public record ProductDetailResponse(
+        String slug,
+        String name,
+        String oneLiner,
+        String description,
+        String status,
+        String sourceType,
+        String sourceLabel,
+        List<String> tags,
+        String thumbnailUrl,
+        int actYear,
+        String serviceUrl,
+        String githubUrl,
+        List<String> techStack,
+        List<MemberResponse> members,
+        List<String> screenshots
+) {
+    public record MemberResponse(String userName, String roleLabel) {
+    }
+
+    public static ProductDetailResponse from(ProductInfo info) {
+        return ProductDetailResponse.builder()
+                .slug(info.slug())
+                .name(info.name())
+                .oneLiner(info.oneLiner())
+                .description(info.description())
+                .status(info.status())
+                .sourceType(info.sourceType())
+                .sourceLabel(info.sourceLabel())
+                .tags(info.tags())
+                .thumbnailUrl(null)
+                .actYear(info.actYear())
+                .serviceUrl(info.serviceUrl())
+                .githubUrl(info.githubUrl())
+                .techStack(info.techStack())
+                .members(info.members().stream()
+                        .map(m -> new MemberResponse(m.userName(), m.roleLabel()))
+                        .toList())
+                .screenshots(List.of()) // 스크린샷 업로드는 후속 작업
+                .build();
+    }
+}

--- a/src/main/java/org/forif_backend/web/product/dto/ProductResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/ProductResponse.java
@@ -1,0 +1,37 @@
+package org.forif_backend.web.product.dto;
+
+import lombok.Builder;
+import org.forif_backend.application.product.dto.ProductInfo;
+
+import java.util.List;
+
+@Builder
+public record ProductResponse(
+        String slug,
+        String name,
+        String oneLiner,
+        String status,
+        String sourceType,
+        String sourceLabel,
+        List<String> tags,
+        String thumbnailUrl,
+        int actYear
+) {
+    public static ProductResponse from(ProductInfo info) {
+        return ProductResponse.builder()
+                .slug(info.slug())
+                .name(info.name())
+                .oneLiner(info.oneLiner())
+                .status(info.status())
+                .sourceType(info.sourceType())
+                .sourceLabel(info.sourceLabel())
+                .tags(info.tags())
+                .thumbnailUrl(null) // 썸네일 업로드는 후속 작업
+                .actYear(info.actYear())
+                .build();
+    }
+
+    public static List<ProductResponse> fromList(List<ProductInfo> infos) {
+        return infos.stream().map(ProductResponse::from).toList();
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항

부원들이 만든 서비스를 `{slug}.forif.org` 서브도메인과 함께 홈페이지에 소개하는 프로덕트 기능의 백엔드.

### 도메인
- `tb_product` / `tb_product_member` — 등록 신청(PENDING/REJECTED)과 게시(LIVE/DEV/PAUSED/RETIRED)를 단일 엔티티로 관리
- 신청자는 자동으로 팀원("신청자")으로 등록

### API
- **공개**: `GET /products`(게시 목록), `GET /products/{slug}`(상세) — 인증 불필요 (SecurityConfig permitAll)
- **부원**: `POST /products/applications`(신청), `GET /products/applications/me`(내 신청 현황·검토 결과)
- **운영진**(ROLE_ADMIN): 전체 목록, 승인, 반려(사유), 게시 상태 변경, 삭제

### 입력 검증 (보안 검토 반영)
- slug: 영소문자·숫자·하이픈 3~20자, 예약어 금지, 중복 409 (저장 경합은 UNIQUE 제약 catch)
- URL 필드 http(s) 스킴 강제 — `javascript:` 스크립트 URL 주입 차단
- 상세 소개 2000자, 태그/기술 스택 개수·길이 제한, 유저당 검토 대기 3건 제한

## 배포
- local/dev는 ddl-auto: update로 테이블 자동 생성, release 배포 시 `docs/create-product-tables.sql` 선실행

## 검증
- 전체 테스트 통과, 로컬에서 신청→승인→게시/반려·권한(403)·slug 검증·URL 주입 등 curl E2E 완료
- 프론트(웹 신청 화면 + admin 검토 화면)와 연동해 브라우저 E2E 완료 (frontend#140 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)