### PR TITLE
perf: 프로덕트 목록 조회 N+1 제거 (FOR-106)

### DIFF
--- a/src/main/java/org/forif_backend/application/product/ProductService.java
+++ b/src/main/java/org/forif_backend/application/product/ProductService.java
@@ -136,9 +136,7 @@ public class ProductService {
     }
 
     private void validatePendingLimit(Long userId) {
-        long pendingCount = productRepository.findAllByApplicantId(userId).stream()
-                .filter(p -> p.getStatus() == ProductStatus.PENDING)
-                .count();
+        long pendingCount = productRepository.countByApplicantIdAndStatus(userId, ProductStatus.PENDING);
         if (pendingCount >= MAX_PENDING_PER_USER) {
             throw new ForifException(ErrorCode.PRODUCT_PENDING_LIMIT);
         }

--- a/src/main/java/org/forif_backend/domain/product/ProductRepository.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductRepository.java
@@ -13,6 +13,9 @@ public interface ProductRepository {
 
     boolean existsBySlug(String slug);
 
+    /** 신청자의 특정 상태 프로덕트 수 (검토 대기 제한 검사용) */
+    long countByApplicantIdAndStatus(Long userId, ProductStatus status);
+
     /** 게시된(승인 이후) 프로덕트 목록 — 최신 연도순 */
     List<Product> findAllPublished();
 

--- a/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductJpaRepository.java
@@ -1,6 +1,7 @@
 package org.forif_backend.infrastructure.persistence.product;
 
 import org.forif_backend.domain.product.Product;
+import org.forif_backend.domain.product.ProductStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,12 +11,23 @@ import java.util.Optional;
 
 public interface ProductJpaRepository extends JpaRepository<Product, Integer> {
 
-    Optional<Product> findBySlug(String slug);
+    @Query("""
+            SELECT DISTINCT p FROM Product p
+            JOIN FETCH p.applicant
+            LEFT JOIN FETCH p.members
+            WHERE p.slug = :slug
+            """)
+    Optional<Product> findBySlug(@Param("slug") String slug);
 
     boolean existsBySlug(String slug);
 
+    long countByApplicantIdAndStatus(Long applicantId, ProductStatus status);
+
+    // 응답 변환(ProductInfo)에서 신청자와 팀원을 모두 사용하므로 함께 조회한다 (N+1 방지)
     @Query("""
-            SELECT p FROM Product p
+            SELECT DISTINCT p FROM Product p
+            JOIN FETCH p.applicant
+            LEFT JOIN FETCH p.members
             WHERE p.status IN (org.forif_backend.domain.product.ProductStatus.LIVE,
                                org.forif_backend.domain.product.ProductStatus.DEV,
                                org.forif_backend.domain.product.ProductStatus.PAUSED,
@@ -24,8 +36,20 @@ public interface ProductJpaRepository extends JpaRepository<Product, Integer> {
             """)
     List<Product> findAllPublished();
 
-    @Query("SELECT p FROM Product p WHERE p.applicant.id = :userId ORDER BY p.id DESC")
+    @Query("""
+            SELECT DISTINCT p FROM Product p
+            JOIN FETCH p.applicant
+            LEFT JOIN FETCH p.members
+            WHERE p.applicant.id = :userId
+            ORDER BY p.id DESC
+            """)
     List<Product> findAllByApplicantId(@Param("userId") Long userId);
 
-    List<Product> findAllByOrderByIdDesc();
+    @Query("""
+            SELECT DISTINCT p FROM Product p
+            JOIN FETCH p.applicant
+            LEFT JOIN FETCH p.members
+            ORDER BY p.id DESC
+            """)
+    List<Product> findAllForAdmin();
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/product/ProductRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.forif_backend.infrastructure.persistence.product;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.domain.product.Product;
 import org.forif_backend.domain.product.ProductRepository;
+import org.forif_backend.domain.product.ProductStatus;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -35,6 +36,11 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public long countByApplicantIdAndStatus(Long userId, ProductStatus status) {
+        return productJpaRepository.countByApplicantIdAndStatus(userId, status);
+    }
+
+    @Override
     public List<Product> findAllPublished() {
         return productJpaRepository.findAllPublished();
     }
@@ -46,7 +52,7 @@ public class ProductRepositoryImpl implements ProductRepository {
 
     @Override
     public List<Product> findAll() {
-        return productJpaRepository.findAllByOrderByIdDesc();
+        return productJpaRepository.findAllForAdmin();
     }
 
     @Override


### PR DESCRIPTION
## 문제

프로덕트 목록 조회 쿼리에 `JOIN FETCH`가 없는데, 응답 변환(`ProductInfo.from`)에서 `getApplicant()`와 `getMembers()`를 접근한다. 둘 다 LAZY라 프로덕트 건마다 추가 쿼리가 나간다.

FOR-105 배포 직후 코드 점검 중 발견했다. 현재는 등록된 프로덕트가 0건이라 실사용 영향은 없지만, 프로덕트가 쌓이면 목록 페이지가 선형으로 느려진다.

## 변경 사항

- 게시 목록 / 내 신청 현황 / 어드민 전체 목록 / 상세 조회 쿼리에 `JOIN FETCH p.applicant`, `LEFT JOIN FETCH p.members` 적용
- 컬렉션 조인으로 생기는 중복 행은 `SELECT DISTINCT`로 제거 (기존 `StudyJpaRepository.findStudyByIdWithTags`와 동일한 방식)
- 이름과 동작이 어긋나던 `findAllByOrderByIdDesc()` → `findAllForAdmin()`으로 정리
- 검토 대기 제한 검사가 신청자의 프로덕트 엔티티를 전부 로딩해 스트림으로 세던 것을 `countByApplicantIdAndStatus` 쿼리로 변경 (fetch join 적용으로 이 경로가 더 무거워지는 것을 방지)

## 검증

로컬에 게시 프로덕트 4건(각 팀원 3명)을 넣고 `GET /api/v1/products` 1회 호출 시 발생하는 SQL을 실측 비교했다.

| | SQL 쿼리 수 | 응답 항목 | 중복 |
|---|---|---|---|
| 변경 전 (dev) | **7회** | 4건 | 0 |
| 변경 후 (FOR-106) | **1회** | 4건 | 0 |

응답 내용(태그·기술 스택 등)은 변경 전후 동일. 상세(팀원 3명 노출), 내 신청 현황, 어드민 목록, 신청 개수 제한(4번째 신청 시 FOR116-400)까지 회귀 없음을 확인했다. 전체 테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)