### PR TITLE
feat: 운영진의 프로덕트 썸네일·정보 관리 (FOR-107)

### DIFF
--- a/src/main/java/org/forif_backend/application/product/ProductService.java
+++ b/src/main/java/org/forif_backend/application/product/ProductService.java
@@ -2,7 +2,9 @@ package org.forif_backend.application.product;
 
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.application.product.dto.CreateProductApplicationCommand;
+import org.forif_backend.application.file.port.out.FilePort;
 import org.forif_backend.application.product.dto.ProductInfo;
+import org.forif_backend.application.product.dto.UpdateProductCommand;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.domain.product.Product;
@@ -14,6 +16,7 @@ import org.forif_backend.domain.user.UserRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,13 +33,17 @@ public class ProductService {
             "www", "dev", "api", "admin", "mail", "apply", "applications", "products", "forif"
     );
 
+    private static final String THUMBNAIL_DIRECTORY = "products/thumbnails";
+    private static final long MAX_THUMBNAIL_SIZE = 5 * 1024 * 1024; // 5MB
+
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
+    private final FilePort filePort;
 
     /** 게시된 프로덕트 목록 (공개) */
     public List<ProductInfo> getPublishedProducts() {
         return productRepository.findAllPublished().stream()
-                .map(ProductInfo::from)
+                .map(this::toInfo)
                 .toList();
     }
 
@@ -45,7 +52,7 @@ public class ProductService {
         Product product = productRepository.findBySlug(slug)
                 .filter(p -> p.getStatus().isPublished())
                 .orElseThrow(() -> new ForifException(ErrorCode.PRODUCT_NOT_FOUND));
-        return ProductInfo.from(product);
+        return toInfo(product);
     }
 
     /** 유저당 동시에 검토 대기 상태로 둘 수 있는 신청 수 */
@@ -77,7 +84,7 @@ public class ProductService {
         product.addMember(ProductMember.create(product, applicant.getUserName(), "신청자"));
 
         try {
-            return ProductInfo.from(productRepository.save(product));
+            return toInfo(productRepository.save(product));
         } catch (DataIntegrityViolationException e) {
             // slug 중복 검사와 저장 사이의 경합 — UNIQUE 제약이 최종 방어선
             throw new ForifException(ErrorCode.PRODUCT_SLUG_ALREADY_EXISTS);
@@ -87,7 +94,7 @@ public class ProductService {
     /** 내 신청 현황 (부원) */
     public List<ProductInfo> getMyApplications(Long userId) {
         return productRepository.findAllByApplicantId(userId).stream()
-                .map(ProductInfo::from)
+                .map(this::toInfo)
                 .toList();
     }
 
@@ -95,7 +102,7 @@ public class ProductService {
 
     public List<ProductInfo> getAllProducts() {
         return productRepository.findAll().stream()
-                .map(ProductInfo::from)
+                .map(this::toInfo)
                 .toList();
     }
 
@@ -112,6 +119,41 @@ public class ProductService {
     @Transactional
     public void changeProductStatus(Integer productId, ProductStatus status) {
         getProductById(productId).changeStatus(status);
+    }
+
+    /** 프로덕트 정보 수정 (운영진) — null 필드는 변경하지 않는다 */
+    @Transactional
+    public ProductInfo updateProduct(Integer productId, UpdateProductCommand command) {
+        Product product = getProductById(productId);
+        product.updateInfo(
+                blankToNull(command.name()),
+                blankToNull(command.oneLiner()),
+                blankToNull(command.description()),
+                command.sourceLabel() == null ? null : command.sourceLabel().trim(),
+                command.tags() == null ? null : joinCsvOrEmpty(command.tags(), 200),
+                command.techStack() == null ? null : joinCsvOrEmpty(command.techStack(), 300),
+                command.serviceUrl() == null ? null : requireHttpUrlOrEmpty(command.serviceUrl()),
+                command.githubUrl() == null ? null : requireHttpUrlOrEmpty(command.githubUrl())
+        );
+        return toInfo(product);
+    }
+
+    /** 썸네일 이미지 등록·교체 (운영진) */
+    @Transactional
+    public String updateThumbnail(Integer productId, MultipartFile file) {
+        Product product = getProductById(productId);
+        validateImageFile(file);
+
+        String objectKey = filePort.uploadFile(file, THUMBNAIL_DIRECTORY);
+        product.updateThumbnail(objectKey);
+
+        return toFileViewUrl(objectKey);
+    }
+
+    /** 썸네일 제거 (운영진) */
+    @Transactional
+    public void deleteThumbnail(Integer productId) {
+        getProductById(productId).updateThumbnail(null);
     }
 
     @Transactional
@@ -157,6 +199,48 @@ public class ProductService {
             throw new ForifException(ErrorCode.PRODUCT_INPUT_TOO_LONG);
         }
         return joined;
+    }
+
+    private ProductInfo toInfo(Product product) {
+        return ProductInfo.from(product, toFileViewUrl(product.getThumbnailObjectKey()));
+    }
+
+    /** 저장된 objectKey를 클라이언트가 볼 수 있는 조회 URL로 변환한다 */
+    private String toFileViewUrl(String objectKey) {
+        if (objectKey == null || objectKey.isBlank()) {
+            return null;
+        }
+        if (objectKey.startsWith("http://") || objectKey.startsWith("https://")) {
+            return objectKey;
+        }
+        return filePort.generatePresignedViewUrl(objectKey).presignedUrl();
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty() || file.getSize() > MAX_THUMBNAIL_SIZE) {
+            throw new ForifException(ErrorCode.INVALID_FILE_ATTACHMENT);
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new ForifException(ErrorCode.INVALID_FILE_ATTACHMENT);
+        }
+    }
+
+    /** 수정 요청에서 빈 리스트는 "값 비우기"를 뜻하므로 빈 문자열로 남긴다 */
+    private String joinCsvOrEmpty(List<String> values, int maxLength) {
+        String joined = joinCsv(values, maxLength);
+        return joined == null ? "" : joined;
+    }
+
+    private String requireHttpUrlOrEmpty(String value) {
+        if (value.isBlank()) {
+            return "";
+        }
+        return requireHttpUrl(value);
+    }
+
+    private String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value.trim();
     }
 
     /** 링크로 렌더링되는 값이므로 http(s) 스킴만 허용한다 (javascript: 등 주입 방지) */

--- a/src/main/java/org/forif_backend/application/product/dto/ProductInfo.java
+++ b/src/main/java/org/forif_backend/application/product/dto/ProductInfo.java
@@ -18,6 +18,7 @@ public record ProductInfo(
         String status,
         String sourceType,
         String sourceLabel,
+        String thumbnailUrl,
         List<String> tags,
         List<String> techStack,
         String serviceUrl,
@@ -39,7 +40,12 @@ public record ProductInfo(
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     public static ProductInfo from(Product product) {
+        return from(product, null);
+    }
+
+    public static ProductInfo from(Product product, String thumbnailUrl) {
         return ProductInfo.builder()
+                .thumbnailUrl(thumbnailUrl)
                 .productId(product.getId())
                 .slug(product.getSlug())
                 .name(product.getName())

--- a/src/main/java/org/forif_backend/application/product/dto/UpdateProductCommand.java
+++ b/src/main/java/org/forif_backend/application/product/dto/UpdateProductCommand.java
@@ -1,0 +1,19 @@
+package org.forif_backend.application.product.dto;
+
+import java.util.List;
+
+/**
+ * 운영진의 프로덕트 정보 수정 명령.
+ * null인 필드는 변경하지 않으며, 빈 값(빈 문자열·빈 리스트)은 해당 항목을 비우는 것을 뜻한다.
+ */
+public record UpdateProductCommand(
+        String name,
+        String oneLiner,
+        String description,
+        String sourceLabel,
+        List<String> tags,
+        List<String> techStack,
+        String serviceUrl,
+        String githubUrl
+) {
+}

--- a/src/main/java/org/forif_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/forif_backend/common/exception/GlobalExceptionHandler.java
@@ -86,6 +86,17 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 업로드 용량 초과는 컨트롤러 진입 전에 발생하므로 별도로 400으로 응답한다.
+     */
+    @ExceptionHandler(org.springframework.web.multipart.MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<?>> handleMaxUploadSizeExceeded(
+            org.springframework.web.multipart.MaxUploadSizeExceededException e) {
+        log.warn("업로드 용량 초과: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.INVALID_FILE_ATTACHMENT;
+        return new ResponseEntity<>(ApiResponse.error(errorCode), errorCode.getHttpStatus());
+    }
+
+    /**
      * 처리하지 못한 나머지 모든 예외를 처리하는 최종 핸들러
      */
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/forif_backend/domain/product/Product.java
+++ b/src/main/java/org/forif_backend/domain/product/Product.java
@@ -132,4 +132,29 @@ public class Product extends BaseTimeEntity {
     public void updateSourceLabel(String sourceLabel) {
         this.sourceLabel = sourceLabel;
     }
+
+    public void updateThumbnail(String thumbnailObjectKey) {
+        this.thumbnailObjectKey = thumbnailObjectKey;
+    }
+
+    /**
+     * 운영진의 프로덕트 정보 수정. null인 인자는 변경하지 않는다.
+     * slug(서브도메인)와 상태는 별도 경로로만 변경할 수 있다.
+     */
+    public void updateInfo(String name, String oneLiner, String description, String sourceLabel,
+                           String tags, String techStack, String serviceUrl, String githubUrl) {
+        if (name != null) this.name = name;
+        if (oneLiner != null) this.oneLiner = oneLiner;
+        if (description != null) this.description = description;
+        // 선택 항목은 빈 문자열을 "값 비우기"로 해석한다
+        if (sourceLabel != null) this.sourceLabel = emptyToNull(sourceLabel);
+        if (tags != null) this.tags = emptyToNull(tags);
+        if (techStack != null) this.techStack = emptyToNull(techStack);
+        if (serviceUrl != null) this.serviceUrl = emptyToNull(serviceUrl);
+        if (githubUrl != null) this.githubUrl = emptyToNull(githubUrl);
+    }
+
+    private static String emptyToNull(String value) {
+        return value.isBlank() ? null : value;
+    }
 }

--- a/src/main/java/org/forif_backend/web/product/AdminProductController.java
+++ b/src/main/java/org/forif_backend/web/product/AdminProductController.java
@@ -6,18 +6,23 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.application.product.ProductService;
+import org.forif_backend.application.product.dto.UpdateProductCommand;
 import org.forif_backend.common.dto.response.ApiResponse;
+import org.forif_backend.application.product.dto.ProductInfo;
 import org.forif_backend.domain.product.ProductStatus;
 import org.forif_backend.web.product.dto.AdminProductResponse;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -66,6 +71,35 @@ public class AdminProductController {
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
     }
 
+    @Operation(summary = "프로덕트 정보 수정", description = "프로덕트의 소개·링크·기술 스택 등을 수정합니다. 전달하지 않은 필드는 변경되지 않습니다.")
+    @PatchMapping("/{productId}")
+    public ResponseEntity<ApiResponse<AdminProductResponse>> updateProduct(
+            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @Valid @RequestBody UpdateProductRequest request
+    ) {
+        ProductInfo info = productService.updateProduct(productId, request.toCommand());
+        return ResponseEntity.ok(ApiResponse.success(AdminProductResponse.from(info)));
+    }
+
+    @Operation(summary = "썸네일 등록·교체", description = "프로덕트 대표 이미지를 등록하거나 교체합니다. 5MB 이하 이미지 파일만 허용됩니다.")
+    @PostMapping(value = "/{productId}/thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<ThumbnailResponse>> updateThumbnail(
+            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @RequestPart("file") MultipartFile file
+    ) {
+        String thumbnailUrl = productService.updateThumbnail(productId, file);
+        return ResponseEntity.ok(ApiResponse.success(new ThumbnailResponse(thumbnailUrl)));
+    }
+
+    @Operation(summary = "썸네일 삭제", description = "등록된 대표 이미지를 제거합니다. 제거하면 기본 플레이스홀더가 표시됩니다.")
+    @DeleteMapping("/{productId}/thumbnail")
+    public ResponseEntity<ApiResponse<Void>> deleteThumbnail(
+            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId
+    ) {
+        productService.deleteThumbnail(productId);
+        return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
+    }
+
     @Operation(summary = "프로덕트 삭제", description = "프로덕트(신청 포함)를 삭제합니다.")
     @DeleteMapping("/{productId}")
     public ResponseEntity<ApiResponse<Void>> deleteProduct(
@@ -82,6 +116,43 @@ public class AdminProductController {
         @NotBlank
         @Length(max = 500)
         private String rejectReason;
+    }
+
+    public record ThumbnailResponse(String thumbnailUrl) {
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class UpdateProductRequest {
+        @Length(max = 100)
+        private String name;
+
+        @Length(max = 200)
+        private String oneLiner;
+
+        @Length(max = 2000)
+        private String description;
+
+        @Length(max = 100)
+        private String sourceLabel;
+
+        @Size(max = 10)
+        private List<String> tags;
+
+        @Size(max = 10)
+        private List<String> techStack;
+
+        @Length(max = 300)
+        private String serviceUrl;
+
+        @Length(max = 300)
+        private String githubUrl;
+
+        public UpdateProductCommand toCommand() {
+            return new UpdateProductCommand(name, oneLiner, description, sourceLabel,
+                    tags, techStack, serviceUrl, githubUrl);
+        }
     }
 
     @Getter

--- a/src/main/java/org/forif_backend/web/product/dto/AdminProductResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/AdminProductResponse.java
@@ -15,6 +15,7 @@ public record AdminProductResponse(
         String status,
         String sourceType,
         String sourceLabel,
+        String thumbnailUrl,
         List<String> tags,
         List<String> techStack,
         String serviceUrl,
@@ -35,6 +36,7 @@ public record AdminProductResponse(
                 .status(info.status())
                 .sourceType(info.sourceType())
                 .sourceLabel(info.sourceLabel())
+                .thumbnailUrl(info.thumbnailUrl())
                 .tags(info.tags())
                 .techStack(info.techStack())
                 .serviceUrl(info.serviceUrl())

--- a/src/main/java/org/forif_backend/web/product/dto/ProductDetailResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/ProductDetailResponse.java
@@ -36,7 +36,7 @@ public record ProductDetailResponse(
                 .sourceType(info.sourceType())
                 .sourceLabel(info.sourceLabel())
                 .tags(info.tags())
-                .thumbnailUrl(null)
+                .thumbnailUrl(info.thumbnailUrl())
                 .actYear(info.actYear())
                 .serviceUrl(info.serviceUrl())
                 .githubUrl(info.githubUrl())

--- a/src/main/java/org/forif_backend/web/product/dto/ProductResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/ProductResponse.java
@@ -26,7 +26,7 @@ public record ProductResponse(
                 .sourceType(info.sourceType())
                 .sourceLabel(info.sourceLabel())
                 .tags(info.tags())
-                .thumbnailUrl(null) // 썸네일 업로드는 후속 작업
+                .thumbnailUrl(info.thumbnailUrl())
                 .actYear(info.actYear())
                 .build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 20MB
+
   jackson:
     property-naming-strategy: SNAKE_CASE
     time-zone: Asia/Seoul


### PR DESCRIPTION
## 문제

프로덕트가 등록된 뒤에는 **대표 이미지도 소개 내용도 아무도 고칠 수 없었다.** `thumbnail_object_key` 컬럼과 `thumbnail_url` 응답 필드는 있었지만 쓰기 경로가 전혀 없어 항상 null이었고, 정보 수정 API도 없어 오타 하나를 고치려면 운영진이 삭제 → 부원이 재신청 → 재승인을 거쳐야 했다.

## 변경 사항

- `POST/DELETE /admin/products/{id}/thumbnail` — 대표 이미지 등록·교체·삭제
- `PATCH /admin/products/{id}` — 소개·출처 라벨·기술 스택·링크 수정 (전달하지 않은 필드는 유지, 빈 값은 해당 항목 비우기)
- 하드코딩 null이던 `thumbnail_url`을 실제 값으로 배선. objectKey를 저장하고 응답 조립 시 조회 URL로 변환하는 기존 관행(`HackathonService.toFileViewUrl`)을 따랐다 — 수료증처럼 만료되는 presigned URL을 DB에 저장하지 않는다.

### 함께 고친 것: multipart 용량 설정 부재

`spring.servlet.multipart.max-file-size`가 어느 yml에도 없어 Spring 기본값 1MB가 적용되고 있었다. 1MB 초과 업로드는 컨트롤러 진입 전에 터져 **500**으로 응답됐다(핸들러 없음). 5MB로 설정하고 `MaxUploadSizeExceededException` → 400 핸들러를 추가했다. 이건 프로덕트뿐 아니라 기존 스터디 썸네일·공지 이미지 업로드에도 해당되던 문제다.

## 배포

DB 스키마 변경 **불필요** — `thumbnail_object_key` 컬럼은 FOR-105에서 이미 생성됨.

## 검증

로컬에서 8개 케이스 확인: 업로드 → 목록·상세 반영 → 파일 서빙(200) → 부분 수정(미전달 필드 유지) → 비이미지 거부(400) → 5MB 초과 거부(400) → 삭제 → 부원 권한 차단(403). 전체 테스트 통과.

dev(FOR-106 N+1 수정)를 병합해 충돌 없음을 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)