### PR TITLE
feat(semester): 활동 학기 전환 기능 (FOR-108)

### DIFF
--- a/docs/create-semester-tables.sql
+++ b/docs/create-semester-tables.sql
@@ -1,0 +1,30 @@
+-- 활동 학기 관리 테이블 (FOR-108)
+-- local/dev는 ddl-auto: update로 자동 생성되므로 release 배포 전에만 수동 실행한다.
+
+CREATE TABLE IF NOT EXISTS tb_active_semester (
+    active_semester_id INT         NOT NULL,
+    act_year           INT         NOT NULL,
+    act_semester       INT         NOT NULL,
+    updated_by         BIGINT      NULL,
+    created_at         DATETIME(6) NOT NULL,
+    updated_at         DATETIME(6) NOT NULL,
+    PRIMARY KEY (active_semester_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tb_semester_change_log (
+    log_id        BIGINT      NOT NULL AUTO_INCREMENT,
+    from_year     INT         NOT NULL,
+    from_semester INT         NOT NULL,
+    to_year       INT         NOT NULL,
+    to_semester   INT         NOT NULL,
+    changed_by    BIGINT      NOT NULL,
+    created_at    DATETIME(6) NOT NULL,
+    updated_at    DATETIME(6) NOT NULL,
+    PRIMARY KEY (log_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+-- 초기값: 배포 직후 동작이 바뀌지 않도록 현재 운영 중인 학기를 넣는다.
+-- 값이 없으면 서비스가 날짜 기준으로 폴백하지만, 명시 설정이 원칙이다.
+INSERT INTO tb_active_semester (active_semester_id, act_year, act_semester, updated_by, created_at, updated_at)
+VALUES (1, 2026, 1, NULL, NOW(6), NOW(6))
+ON DUPLICATE KEY UPDATE active_semester_id = active_semester_id;

--- a/docs/create-semester-tables.sql
+++ b/docs/create-semester-tables.sql
@@ -1,5 +1,9 @@
 -- 활동 학기 관리 테이블 (FOR-108)
--- local/dev는 ddl-auto: update로 자동 생성되므로 release 배포 전에만 수동 실행한다.
+--
+-- 로컬(local 프로파일)만 ddl-auto: update라 자동 생성된다.
+-- dev 서버와 운영 서버는 release 프로파일 = ddl-auto: validate 이므로
+-- JAR을 교체하기 "전에" 이 스크립트를 먼저 돌려야 한다.
+-- 순서를 바꾸면 검증 실패로 기동에 실패하고 컨테이너가 재시작을 반복한다.
 
 CREATE TABLE IF NOT EXISTS tb_active_semester (
     active_semester_id INT         NOT NULL,

--- a/src/main/java/org/forif_backend/application/product/ProductService.java
+++ b/src/main/java/org/forif_backend/application/product/ProductService.java
@@ -40,14 +40,14 @@ public class ProductService {
     private final UserRepository userRepository;
     private final FilePort filePort;
 
-    /** 게시된 프로덕트 목록 (공개) */
+    /** 게시된 서비스 목록 (공개) */
     public List<ProductInfo> getPublishedProducts() {
         return productRepository.findAllPublished().stream()
                 .map(this::toInfo)
                 .toList();
     }
 
-    /** 게시된 프로덕트 상세 (공개) */
+    /** 게시된 서비스 상세 (공개) */
     public ProductInfo getPublishedProduct(String slug) {
         Product product = productRepository.findBySlug(slug)
                 .filter(p -> p.getStatus().isPublished())
@@ -58,7 +58,7 @@ public class ProductService {
     /** 유저당 동시에 검토 대기 상태로 둘 수 있는 신청 수 */
     private static final int MAX_PENDING_PER_USER = 3;
 
-    /** 프로덕트 등록 신청 (부원) */
+    /** 서비스 등록 신청 (부원) */
     @Transactional
     public ProductInfo applyProduct(Long userId, CreateProductApplicationCommand command) {
         User applicant = userRepository.findUserById(userId)
@@ -121,7 +121,7 @@ public class ProductService {
         getProductById(productId).changeStatus(status);
     }
 
-    /** 프로덕트 정보 수정 (운영진) — null 필드는 변경하지 않는다 */
+    /** 서비스 정보 수정 (운영진) — null 필드는 변경하지 않는다 */
     @Transactional
     public ProductInfo updateProduct(Integer productId, UpdateProductCommand command) {
         Product product = getProductById(productId);

--- a/src/main/java/org/forif_backend/application/product/dto/UpdateProductCommand.java
+++ b/src/main/java/org/forif_backend/application/product/dto/UpdateProductCommand.java
@@ -3,7 +3,7 @@ package org.forif_backend.application.product.dto;
 import java.util.List;
 
 /**
- * 운영진의 프로덕트 정보 수정 명령.
+ * 운영진의 서비스 정보 수정 명령.
  * null인 필드는 변경하지 않으며, 빈 값(빈 문자열·빈 리스트)은 해당 항목을 비우는 것을 뜻한다.
  */
 public record UpdateProductCommand(

--- a/src/main/java/org/forif_backend/application/semester/SemesterService.java
+++ b/src/main/java/org/forif_backend/application/semester/SemesterService.java
@@ -11,7 +11,7 @@ import org.forif_backend.domain.semester.SemesterChangeLog;
 import org.forif_backend.domain.semester.SemesterRepository;
 import org.forif_backend.application.semester.dto.SemesterChangePreview;
 import org.forif_backend.domain.hackathon.HackathonRepository;
-import org.forif_backend.domain.team.ForifTeam;
+import org.forif_backend.domain.study.StudyUserRepository;
 import org.forif_backend.domain.team.ForifTeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +37,7 @@ public class SemesterService {
     private final SemesterRepository semesterRepository;
     private final ForifTeamRepository forifTeamRepository;
     private final HackathonRepository hackathonRepository;
+    private final StudyUserRepository studyUserRepository;
 
     /**
      * 현재 활동 학기.
@@ -115,49 +116,10 @@ public class SemesterService {
                 current,
                 SemesterInfo.of(targetYear, targetSemester),
                 forifTeamRepository.findByYearAndSemester(targetYear, targetSemester).size(),
-                forifTeamRepository.findByYearAndSemester(current.actYear(), current.actSemester()).size(),
-                !hackathonRepository.findEvents(targetYear, targetSemester, null).isEmpty()
+                !hackathonRepository.findEvents(targetYear, targetSemester, null).isEmpty(),
+                studyUserRepository.countBySemester(current.actYear(), current.actSemester()),
+                studyUserRepository.countIssuedCertificatesBySemester(current.actYear(), current.actSemester())
         );
-    }
-
-    /**
-     * 학기 전환 + 부수 작업.
-     * copyTeamMembers가 true면 현재 학기 운영진 명단을 대상 학기로 복제한다
-     * (복제하지 않으면 운영진 소개 페이지가 빈다).
-     */
-    @Transactional
-    public SemesterInfo changeActiveWithRollover(int actYear, int actSemester,
-                                                 boolean copyTeamMembers, Long changedBy) {
-        SemesterInfo previous = getActive();
-        SemesterInfo changed = changeActive(actYear, actSemester, changedBy);
-
-        if (copyTeamMembers && !previous.equals(changed)) {
-            copyTeamMembers(previous, changed);
-        }
-        return changed;
-    }
-
-    /** 이전 학기 운영진 명단을 새 학기로 복제 (이미 있는 사람은 건너뜀) */
-    private void copyTeamMembers(SemesterInfo from, SemesterInfo to) {
-        List<ForifTeam> sources = forifTeamRepository.findByYearAndSemester(from.actYear(), from.actSemester());
-        int copied = 0;
-
-        for (ForifTeam source : sources) {
-            Long userId = source.getUser() != null ? source.getUser().getId() : null;
-            if (userId == null) continue;
-            if (forifTeamRepository.existsByActYearAndActSemesterAndUserId(
-                    to.actYear(), to.actSemester(), userId)) {
-                continue;
-            }
-
-            ForifTeam copy = ForifTeam.create(source.getUser(), to.actYear(), to.actSemester(),
-                    source.getClubDepartment());
-            copy.update(source.getUserTitle(), source.getClubDepartment(), source.getIntroTag(),
-                    source.getSelfIntro(), source.getProfImgUrl(), source.getGraduateYear());
-            forifTeamRepository.save(copy);
-            copied++;
-        }
-        log.info("운영진 명단 복제: {} → {} ({}명)", from.label(), to.label(), copied);
     }
 
     private void validate(int actYear, int actSemester) {

--- a/src/main/java/org/forif_backend/application/semester/SemesterService.java
+++ b/src/main/java/org/forif_backend/application/semester/SemesterService.java
@@ -1,0 +1,173 @@
+package org.forif_backend.application.semester;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.common.util.DateUtils;
+import org.forif_backend.domain.semester.ActiveSemester;
+import org.forif_backend.domain.semester.SemesterChangeLog;
+import org.forif_backend.domain.semester.SemesterRepository;
+import org.forif_backend.application.semester.dto.SemesterChangePreview;
+import org.forif_backend.domain.hackathon.HackathonRepository;
+import org.forif_backend.domain.team.ForifTeam;
+import org.forif_backend.domain.team.ForifTeamRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 활동 학기 조회·변경.
+ *
+ * 학기는 시스템 날짜가 아니라 운영진이 지정한 값을 따른다.
+ * 날짜 계산(DateUtils)은 설정 행이 아직 없을 때의 초기값으로만 쓰인다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SemesterService {
+
+    /** 학기 선택 목록의 시작 연도 (동아리 창립) */
+    private static final int FIRST_YEAR = 2018;
+
+    private final SemesterRepository semesterRepository;
+    private final ForifTeamRepository forifTeamRepository;
+    private final HackathonRepository hackathonRepository;
+
+    /**
+     * 현재 활동 학기.
+     * 설정 행이 없으면 날짜 기준으로 계산한 값을 반환한다(저장하지는 않는다).
+     */
+    public SemesterInfo getActive() {
+        return semesterRepository.findActive()
+                .map(SemesterInfo::from)
+                .orElseGet(() -> {
+                    log.warn("활동 학기 설정이 없어 날짜 기준값을 사용합니다. 운영진 페이지에서 학기를 지정해주세요.");
+                    return SemesterInfo.of(DateUtils.getCurrentYear(), DateUtils.getCurrentSemester());
+                });
+    }
+
+    public int getActiveYear() {
+        return getActive().actYear();
+    }
+
+    public int getActiveSemester() {
+        return getActive().actSemester();
+    }
+
+    /** 선택 가능한 학기 목록 (창립 학기 ~ 현재 활동 학기의 다음 학기), 최신순 */
+    public List<SemesterInfo> getSelectableSemesters() {
+        SemesterInfo last = getActive().next();
+
+        List<SemesterInfo> semesters = new ArrayList<>();
+        for (int year = FIRST_YEAR; year <= last.actYear(); year++) {
+            for (int semester = 1; semester <= 2; semester++) {
+                if (year == last.actYear() && semester > last.actSemester()) break;
+                semesters.add(SemesterInfo.of(year, semester));
+            }
+        }
+        semesters.sort((a, b) -> a.actYear() != b.actYear()
+                ? Integer.compare(b.actYear(), a.actYear())
+                : Integer.compare(b.actSemester(), a.actSemester()));
+        return semesters;
+    }
+
+    /**
+     * 활동 학기 변경 (회장단 전용 — 권한 검증은 호출부에서 수행).
+     */
+    @Transactional
+    public SemesterInfo changeActive(int actYear, int actSemester, Long changedBy) {
+        validate(actYear, actSemester);
+
+        // 설정 행이 없으면 폴백값이 곧 이전 학기다. 첫 전환도 이력에 남겨야 한다.
+        SemesterInfo previous = getActive();
+        if (previous.actYear() == actYear && previous.actSemester() == actSemester) {
+            return previous;
+        }
+
+        ActiveSemester active = semesterRepository.findActive().orElse(null);
+        SemesterInfo changed;
+        if (active == null) {
+            changed = SemesterInfo.from(semesterRepository.save(
+                    ActiveSemester.create(actYear, actSemester, changedBy)));
+        } else {
+            active.change(actYear, actSemester, changedBy);
+            changed = SemesterInfo.from(active);
+        }
+
+        semesterRepository.saveChangeLog(SemesterChangeLog.of(
+                previous.actYear(), previous.actSemester(), actYear, actSemester, changedBy));
+
+        log.info("활동 학기 변경: {} → {} (by {})", previous.label(), changed.label(), changedBy);
+        return changed;
+    }
+
+    /** 전환 전 영향 미리보기 */
+    public SemesterChangePreview preview(int targetYear, int targetSemester) {
+        validate(targetYear, targetSemester);
+        SemesterInfo current = getActive();
+
+        return new SemesterChangePreview(
+                current,
+                SemesterInfo.of(targetYear, targetSemester),
+                forifTeamRepository.findByYearAndSemester(targetYear, targetSemester).size(),
+                forifTeamRepository.findByYearAndSemester(current.actYear(), current.actSemester()).size(),
+                !hackathonRepository.findEvents(targetYear, targetSemester, null).isEmpty()
+        );
+    }
+
+    /**
+     * 학기 전환 + 부수 작업.
+     * copyTeamMembers가 true면 현재 학기 운영진 명단을 대상 학기로 복제한다
+     * (복제하지 않으면 운영진 소개 페이지가 빈다).
+     */
+    @Transactional
+    public SemesterInfo changeActiveWithRollover(int actYear, int actSemester,
+                                                 boolean copyTeamMembers, Long changedBy) {
+        SemesterInfo previous = getActive();
+        SemesterInfo changed = changeActive(actYear, actSemester, changedBy);
+
+        if (copyTeamMembers && !previous.equals(changed)) {
+            copyTeamMembers(previous, changed);
+        }
+        return changed;
+    }
+
+    /** 이전 학기 운영진 명단을 새 학기로 복제 (이미 있는 사람은 건너뜀) */
+    private void copyTeamMembers(SemesterInfo from, SemesterInfo to) {
+        List<ForifTeam> sources = forifTeamRepository.findByYearAndSemester(from.actYear(), from.actSemester());
+        int copied = 0;
+
+        for (ForifTeam source : sources) {
+            Long userId = source.getUser() != null ? source.getUser().getId() : null;
+            if (userId == null) continue;
+            if (forifTeamRepository.existsByActYearAndActSemesterAndUserId(
+                    to.actYear(), to.actSemester(), userId)) {
+                continue;
+            }
+
+            ForifTeam copy = ForifTeam.create(source.getUser(), to.actYear(), to.actSemester(),
+                    source.getClubDepartment());
+            copy.update(source.getUserTitle(), source.getClubDepartment(), source.getIntroTag(),
+                    source.getSelfIntro(), source.getProfImgUrl(), source.getGraduateYear());
+            forifTeamRepository.save(copy);
+            copied++;
+        }
+        log.info("운영진 명단 복제: {} → {} ({}명)", from.label(), to.label(), copied);
+    }
+
+    private void validate(int actYear, int actSemester) {
+        if (actSemester != 1 && actSemester != 2) {
+            throw new ForifException(ErrorCode.SEMESTER_INVALID);
+        }
+        // 창립 이전이나 현재 연도보다 지나치게 미래인 값은 오입력으로 본다
+        int maxYear = DateUtils.getCurrentYear() + 1;
+        if (actYear < FIRST_YEAR || actYear > maxYear) {
+            throw new ForifException(ErrorCode.SEMESTER_INVALID);
+        }
+    }
+}

--- a/src/main/java/org/forif_backend/application/semester/SemesterTransitionService.java
+++ b/src/main/java/org/forif_backend/application/semester/SemesterTransitionService.java
@@ -1,0 +1,41 @@
+package org.forif_backend.application.semester;
+
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.application.staff.StaffAccountService;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 학기 전환 오케스트레이션.
+ *
+ * 학기 변경과 회장 인수인계를 한 트랜잭션으로 묶는다.
+ * SemesterService가 StaffAccountService를 직접 참조하면 순환 의존이 되므로
+ * (StaffAccountService도 활동 학기를 조회한다) 상위에서 조합한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class SemesterTransitionService {
+
+    private final SemesterService semesterService;
+    private final StaffAccountService staffAccountService;
+
+    /**
+     * 학기 전환 + 차기 회장 인수인계.
+     * 차기 회장은 필수이며 ADMIN 계정을 가진 기존 운영진이어야 한다.
+     * 현 회장 본인을 지정하면 연임으로 처리된다.
+     */
+    @Transactional
+    public SemesterInfo transition(int actYear, int actSemester,
+                                   Long nextPresidentUserId, Long requesterId) {
+        if (nextPresidentUserId == null || !staffAccountService.isAdminAccount(nextPresidentUserId)) {
+            throw new ForifException(ErrorCode.SEMESTER_NEXT_PRESIDENT_REQUIRED);
+        }
+
+        SemesterInfo changed = semesterService.changeActive(actYear, actSemester, requesterId);
+        staffAccountService.handOverPresidency(requesterId, nextPresidentUserId);
+        return changed;
+    }
+}

--- a/src/main/java/org/forif_backend/application/semester/dto/SemesterChangePreview.java
+++ b/src/main/java/org/forif_backend/application/semester/dto/SemesterChangePreview.java
@@ -2,19 +2,30 @@ package org.forif_backend.application.semester.dto;
 
 /**
  * 학기 전환 전 영향 미리보기.
- * 전환 후 운영진 소개 페이지가 비는 등의 사고를 막기 위해 사전에 확인시킨다.
+ * 전환 후 되돌리기 어려운 사고(빈 운영진 페이지, 잘못된 수료증 서명)를 미리 알린다.
  */
 public record SemesterChangePreview(
         SemesterInfo current,
         SemesterInfo target,
-        /** 대상 학기의 운영진 이력 수 (0이면 운영진 소개 페이지가 빈다) */
+        /** 대상 학기의 운영진 명단 수 (0이면 운영진 소개 페이지가 빈다) */
         int targetTeamMemberCount,
-        /** 현재 학기의 운영진 이력 수 (복제 시 생성될 건수) */
-        int currentTeamMemberCount,
         /** 대상 학기에 등록된 해커톤 존재 여부 */
-        boolean targetHackathonExists
+        boolean targetHackathonExists,
+        /** 현재 학기 수강생 수 */
+        long currentMemberCount,
+        /** 현재 학기 수료증 발급 완료 수 */
+        long currentCertificateIssuedCount
 ) {
-    public boolean needsTeamCopy() {
-        return targetTeamMemberCount == 0 && currentTeamMemberCount > 0;
+    /** 전환 후 운영진을 새로 지정해야 하는지 */
+    public boolean needsTeamSetup() {
+        return targetTeamMemberCount == 0;
+    }
+
+    /**
+     * 수료증이 아직 다 나가지 않았는지.
+     * 전환 후 발급하면 신임 회장 서명이 찍히므로 전환 전 발급을 권한다.
+     */
+    public boolean hasPendingCertificates() {
+        return currentMemberCount > currentCertificateIssuedCount;
     }
 }

--- a/src/main/java/org/forif_backend/application/semester/dto/SemesterChangePreview.java
+++ b/src/main/java/org/forif_backend/application/semester/dto/SemesterChangePreview.java
@@ -1,0 +1,20 @@
+package org.forif_backend.application.semester.dto;
+
+/**
+ * 학기 전환 전 영향 미리보기.
+ * 전환 후 운영진 소개 페이지가 비는 등의 사고를 막기 위해 사전에 확인시킨다.
+ */
+public record SemesterChangePreview(
+        SemesterInfo current,
+        SemesterInfo target,
+        /** 대상 학기의 운영진 이력 수 (0이면 운영진 소개 페이지가 빈다) */
+        int targetTeamMemberCount,
+        /** 현재 학기의 운영진 이력 수 (복제 시 생성될 건수) */
+        int currentTeamMemberCount,
+        /** 대상 학기에 등록된 해커톤 존재 여부 */
+        boolean targetHackathonExists
+) {
+    public boolean needsTeamCopy() {
+        return targetTeamMemberCount == 0 && currentTeamMemberCount > 0;
+    }
+}

--- a/src/main/java/org/forif_backend/application/semester/dto/SemesterInfo.java
+++ b/src/main/java/org/forif_backend/application/semester/dto/SemesterInfo.java
@@ -1,0 +1,26 @@
+package org.forif_backend.application.semester.dto;
+
+import org.forif_backend.domain.semester.ActiveSemester;
+
+/**
+ * 활동 학기 값 객체. label은 "26-1" 형태의 표기용 문자열이다.
+ */
+public record SemesterInfo(int actYear, int actSemester, String label) {
+
+    public static SemesterInfo of(int actYear, int actSemester) {
+        return new SemesterInfo(actYear, actSemester, toLabel(actYear, actSemester));
+    }
+
+    public static SemesterInfo from(ActiveSemester activeSemester) {
+        return of(activeSemester.getActYear(), activeSemester.getActSemester());
+    }
+
+    public static String toLabel(int actYear, int actSemester) {
+        return "%02d-%d".formatted(actYear % 100, actSemester);
+    }
+
+    /** 다음 학기 (2학기 다음은 이듬해 1학기) */
+    public SemesterInfo next() {
+        return actSemester == 1 ? of(actYear, 2) : of(actYear + 1, 1);
+    }
+}

--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -194,6 +194,14 @@ public class StaffAccountService {
     }
 
     /**
+     * 회장 권한 검증 — 다른 도메인에서도 사용한다.
+     * 회장직 인수인계가 걸린 작업(학기 전환 등)은 부회장이 할 수 없다.
+     */
+    public void requirePresident(Long userId) {
+        validatePresident(userId);
+    }
+
+    /**
      * 회장단(회장/부회장) 권한 검증
      */
     private StaffAccount validatePresidentTeam(Long userId) {

--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -340,13 +340,39 @@ public class StaffAccountService {
     }
 
     /**
+     * 학기 전환 시 차기 회장 인수인계.
+     * 대상은 ADMIN 계정을 가진 기존 운영진이어야 하며, 현 회장 본인이면(연임) 아무것도 바꾸지 않는다.
+     */
+    @Transactional
+    public void handOverPresidency(Long currentPresidentUserId, Long nextPresidentUserId) {
+        StaffAccount president = validatePresident(currentPresidentUserId);
+
+        if (president.getUserId().equals(nextPresidentUserId)) {
+            return; // 연임
+        }
+
+        StaffAccount next = staffAccountRepository.findByUserIdAndRole(nextPresidentUserId, StaffRole.ADMIN)
+                .orElseThrow(() -> new ForifException(ErrorCode.STAFF_NOT_FOUND));
+
+        next.updateAffiliation("회장");
+        president.updateAffiliation("운영진");
+    }
+
+    /** 회장 후보 = ADMIN 계정을 가진 운영진 */
+    @Transactional(readOnly = true)
+    public boolean isAdminAccount(Long userId) {
+        return staffAccountRepository.existsByUserIdAndRole(userId, StaffRole.ADMIN);
+    }
+
+    /**
      * 회장/부회장 위임
      */
     @Transactional
     public void delegate(Long requesterId, Long targetUserId, String targetAffiliation) {
         StaffAccount president = validatePresident(requesterId);
 
-        if (president.getUserId().equals(targetUserId)) {
+        // 회장 연임(자기 자신 지정)은 허용한다. 부회장 자리에 본인을 넣는 것은 막는다.
+        if (president.getUserId().equals(targetUserId) && !"회장".equals(targetAffiliation)) {
             throw new ForifException(ErrorCode.INVALID_INPUT);
         }
 

--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -9,6 +9,8 @@ import org.forif_backend.application.staff.dto.StaffSignInCommand;
 import org.forif_backend.application.staff.dto.StaffSignInResult;
 import org.forif_backend.common.auth.JwtProvider;
 import org.forif_backend.common.dto.response.CursorPageResponse;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.common.util.DateUtils;
@@ -30,6 +32,7 @@ import java.util.List;
 @Slf4j
 public class StaffAccountService {
 
+    private final SemesterService semesterService;
     private final StaffAccountRepository staffAccountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
@@ -184,6 +187,13 @@ public class StaffAccountService {
     // ==================== 회장단 운영진 관리 ====================
 
     /**
+     * 회장단(회장/부회장) 권한 검증 — 다른 도메인에서도 사용한다.
+     */
+    public void requirePresidentTeam(Long userId) {
+        validatePresidentTeam(userId);
+    }
+
+    /**
      * 회장단(회장/부회장) 권한 검증
      */
     private StaffAccount validatePresidentTeam(Long userId) {
@@ -261,8 +271,9 @@ public class StaffAccountService {
         StaffAccount saved = staffAccountRepository.save(staffAccount);
 
         // 운영진 이력 기록 (StaffAccount 삭제 후에도 남아야 함)
-        int currentYear = DateUtils.getCurrentYear();
-        int currentSemester = DateUtils.getCurrentSemester();
+        SemesterInfo active = semesterService.getActive();
+        int currentYear = active.actYear();
+        int currentSemester = active.actSemester();
         if (!forifTeamRepository.existsByActYearAndActSemesterAndUserId(currentYear, currentSemester, user.getId())) {
             ForifTeam forifTeam = ForifTeam.create(user, currentYear, currentSemester, command.affiliation());
             forifTeamRepository.save(forifTeam);

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -7,6 +7,8 @@ import org.forif_backend.application.file.port.out.FilePort;
 import org.forif_backend.application.staff.dto.CreateMentorCommand;
 import org.forif_backend.application.study.dto.*;
 import org.forif_backend.common.dto.response.CursorPageResponse;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.common.util.DateUtils;
@@ -34,6 +36,7 @@ public class StudyService {
     //       랜덤 생성 후 이메일 발송하는 방식으로 변경 필요.
     private static final String DEFAULT_MENTOR_PASSWORD = "forif1234";
 
+    private final SemesterService semesterService;
     private final StudyRepository studyRepository;
     private final StudyUserRepository studyUserRepository;
     private final UserRepository userRepository;
@@ -95,8 +98,9 @@ public class StudyService {
                 ));
 
         // 2. 현재 학기 정보
-        int currentYear = DateUtils.getCurrentYear();
-        int currentSemester = DateUtils.getCurrentSemester();
+        SemesterInfo active = semesterService.getActive();
+        int currentYear = active.actYear();
+        int currentSemester = active.actSemester();
 
         // 3. SemesterStudiesInfo 리스트 생성 (한 학기에 스터디 1개만)
         List<SemesterStudiesInfo> semesters = studies.stream()
@@ -261,7 +265,8 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
 
         // 생성 시점에 필요한 최소한의 정보만 주입
-        Study study = Study.createPendingStudy(mentor);
+        SemesterInfo semester = semesterService.getActive();
+        Study study = Study.createPendingStudy(mentor, semester.actYear(), semester.actSemester());
 
         List<StudyTag> tags = studyRepository.findAllStudyTagById(request.getStudyTagId());
         User secondaryMentor = resolveSecondaryMentor(mentorId, request.getSecondaryMentorId());

--- a/src/main/java/org/forif_backend/application/team/ForifTeamService.java
+++ b/src/main/java/org/forif_backend/application/team/ForifTeamService.java
@@ -3,8 +3,12 @@ package org.forif_backend.application.team;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.domain.team.ForifTeam;
 import org.forif_backend.domain.team.ForifTeamRepository;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserRepository;
 import org.forif_backend.web.team.dto.ForifTeamResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +20,8 @@ import java.util.List;
 public class ForifTeamService {
 
     private final ForifTeamRepository forifTeamRepository;
+    private final UserRepository userRepository;
+    private final SemesterService semesterService;
 
     @Transactional(readOnly = true)
     public List<ForifTeamResponse> getAllMembers() {
@@ -29,6 +35,31 @@ public class ForifTeamService {
         return forifTeamRepository.findByYearAndSemester(actYear, actSemester).stream()
                 .map(ForifTeamResponse::from)
                 .toList();
+    }
+
+    /**
+     * 운영진 명단에 추가 (회장단 전용 — 권한 검증은 호출부에서 수행).
+     * 학기를 지정하지 않으면 현재 활동 학기에 추가한다.
+     */
+    @Transactional
+    public ForifTeamResponse addMember(Long userId, Integer actYear, Integer actSemester,
+                                       String clubDepartment, String userTitle) {
+        User user = userRepository.findUserById(userId)
+                .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
+
+        SemesterInfo active = semesterService.getActive();
+        int year = actYear != null ? actYear : active.actYear();
+        int semester = actSemester != null ? actSemester : active.actSemester();
+
+        if (forifTeamRepository.existsByActYearAndActSemesterAndUserId(year, semester, userId)) {
+            throw new ForifException(ErrorCode.FORIF_TEAM_MEMBER_ALREADY_EXISTS);
+        }
+
+        ForifTeam forifTeam = ForifTeam.create(user, year, semester, clubDepartment);
+        if (userTitle != null && !userTitle.isBlank()) {
+            forifTeam.update(userTitle, null, null, null, null, null);
+        }
+        return ForifTeamResponse.from(forifTeamRepository.save(forifTeam));
     }
 
     @Transactional

--- a/src/main/java/org/forif_backend/application/user/UserApplyService.java
+++ b/src/main/java/org/forif_backend/application/user/UserApplyService.java
@@ -3,6 +3,8 @@ package org.forif_backend.application.user;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.application.user.dto.ApplyDetailInfo;
 import org.forif_backend.application.user.dto.UserApplyInfo;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.common.type.SortDirection;
@@ -33,6 +35,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class UserApplyService {
+    private final SemesterService semesterService;
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
     private final StudyUserRepository studyUserRepository;
@@ -50,14 +53,15 @@ public class UserApplyService {
         Study study = studyRepository.findStudyById(request.studyId())
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
-        int year = DateUtils.getCurrentYear();
-        int semester = DateUtils.getCurrentSemester();
+        SemesterInfo active = semesterService.getActive();
+        int year = active.actYear();
+        int semester = active.actSemester();
 
         if (request.priority() == 1) {
             if (userRepository.existUserApply(year, semester, user)) {
                 throw new ForifException(ErrorCode.ALREADY_APPLIED_PRIMARY);
             }
-            UserApply userApply = UserApply.applyStudy(user, study, request.applyReason());
+            UserApply userApply = UserApply.applyStudy(user, study, request.applyReason(), year, semester);
             userRepository.createUserApply(userApply);
         } else if (request.priority() == 2) {
             UserApply existingApply = userRepository.findUserApplyByYearAndSemesterAndUser(year, semester, user)
@@ -192,8 +196,9 @@ public class UserApplyService {
         User user = userRepository.findUserById(userId)
                 .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
 
-        int year = DateUtils.getCurrentYear();
-        int semester = DateUtils.getCurrentSemester();
+        SemesterInfo active = semesterService.getActive();
+        int year = active.actYear();
+        int semester = active.actSemester();
 
         Optional<UserApply> applyOpt = userRepository.findUserApplyByYearAndSemesterAndUser(year, semester, user);
 

--- a/src/main/java/org/forif_backend/application/user/UserService.java
+++ b/src/main/java/org/forif_backend/application/user/UserService.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.forif_backend.application.auth.RefreshTokenService;
 import org.forif_backend.application.user.dto.*;
 import org.forif_backend.common.auth.JwtProvider;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.common.dto.response.CursorPageResponse;
@@ -31,6 +33,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class UserService {
 
+    private final SemesterService semesterService;
     private final UserRepository userRepository;
     private final UserApplyRepository userApplyRepository;
     private final StudyRepository studyRepository;
@@ -299,8 +302,9 @@ public class UserService {
     @Transactional(readOnly = true)
     public CursorPageResponse<MemberResponse> getAllMembers(Long cursor, Integer page, int size, String search) {
         long totalElements = userRepository.countUsers(search);
-        int currentYear = DateUtils.getCurrentYear();
-        int currentSemester = DateUtils.getCurrentSemester();
+        SemesterInfo active = semesterService.getActive();
+        int currentYear = active.actYear();
+        int currentSemester = active.actSemester();
 
         if (page != null) {
             List<User> users = userRepository.searchUsersWithOffset(page, size, search);

--- a/src/main/java/org/forif_backend/common/config/SecurityConfig.java
+++ b/src/main/java/org/forif_backend/common/config/SecurityConfig.java
@@ -63,6 +63,8 @@ public class SecurityConfig {
                     "/api/v1/studies/{studyId}",
                     "/api/v1/products",
                     "/api/v1/products/{slug}",
+                    "/api/v1/semesters",
+                    "/api/v1/semesters/current",
                     "/api/v1/hackathons",
                     "/api/v1/hackathons/{hackathonId}",
                     "/api/v1/hackathons/{hackathonId}/submissions/**",

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -97,7 +97,7 @@ public enum ErrorCode {
 
     // Product (서비스 쇼케이스)
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR110-404", "해당 서비스를 찾을 수 없습니다."),
-    PRODUCT_SLUG_INVALID(HttpStatus.BAD_REQUEST, "FOR111-400", "서브도메인은 영소문자·숫자·하이픈 3~20자여야 합니다."),
+    PRODUCT_SLUG_INVALID(HttpStatus.BAD_REQUEST, "FOR111-400", "서브도메인은 영문 소문자·숫자·하이픈 3~20자여야 하며, 하이픈으로 시작하거나 끝날 수 없습니다. www, api, admin 등 예약어는 사용할 수 없습니다."),
     PRODUCT_SLUG_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR112-409", "이미 사용 중인 서브도메인입니다."),
     PRODUCT_NOT_PENDING(HttpStatus.BAD_REQUEST, "FOR113-400", "검토 대기 상태의 신청만 처리할 수 있습니다."),
     PRODUCT_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR114-400", "게시된 서비스의 상태만 변경할 수 있습니다."),

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -105,6 +105,9 @@ public enum ErrorCode {
     PRODUCT_PENDING_LIMIT(HttpStatus.BAD_REQUEST, "FOR116-400", "검토 대기 중인 신청이 너무 많습니다. 검토 완료 후 다시 신청해주세요."),
     PRODUCT_INPUT_TOO_LONG(HttpStatus.BAD_REQUEST, "FOR117-400", "태그 또는 기술 스택이 너무 깁니다."),
 
+    // Semester (활동 학기)
+    SEMESTER_INVALID(HttpStatus.BAD_REQUEST, "FOR120-400", "유효하지 않은 학기입니다."),
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FOR100-500", "서버 내부 오류가 발생했습니다."),
     INVALID_STATUS_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, "FOR101-500", "유효하지 않은 상태 값입니다."),

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -95,12 +95,12 @@ public enum ErrorCode {
     HACKATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR074-409", "이미 등록된 해커톤입니다."),
     HACKATHON_ACTIVE_EVENT_EXISTS(HttpStatus.CONFLICT, "FOR076-409", "진행 중인 해커톤이 있어 새 해커톤을 생성할 수 없습니다."),
 
-    // Product (프로덕트 쇼케이스)
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR110-404", "해당 프로덕트를 찾을 수 없습니다."),
+    // Product (서비스 쇼케이스)
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR110-404", "해당 서비스를 찾을 수 없습니다."),
     PRODUCT_SLUG_INVALID(HttpStatus.BAD_REQUEST, "FOR111-400", "서브도메인은 영소문자·숫자·하이픈 3~20자여야 합니다."),
     PRODUCT_SLUG_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR112-409", "이미 사용 중인 서브도메인입니다."),
     PRODUCT_NOT_PENDING(HttpStatus.BAD_REQUEST, "FOR113-400", "검토 대기 상태의 신청만 처리할 수 있습니다."),
-    PRODUCT_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR114-400", "게시된 프로덕트의 상태만 변경할 수 있습니다."),
+    PRODUCT_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR114-400", "게시된 서비스의 상태만 변경할 수 있습니다."),
     PRODUCT_URL_INVALID(HttpStatus.BAD_REQUEST, "FOR115-400", "URL은 http:// 또는 https:// 로 시작해야 합니다."),
     PRODUCT_PENDING_LIMIT(HttpStatus.BAD_REQUEST, "FOR116-400", "검토 대기 중인 신청이 너무 많습니다. 검토 완료 후 다시 신청해주세요."),
     PRODUCT_INPUT_TOO_LONG(HttpStatus.BAD_REQUEST, "FOR117-400", "태그 또는 기술 스택이 너무 깁니다."),

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -107,6 +107,8 @@ public enum ErrorCode {
 
     // Semester (활동 학기)
     SEMESTER_INVALID(HttpStatus.BAD_REQUEST, "FOR120-400", "유효하지 않은 학기입니다."),
+    FORIF_TEAM_MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR121-409", "이미 해당 학기 운영진 명단에 있습니다."),
+    SEMESTER_NEXT_PRESIDENT_REQUIRED(HttpStatus.BAD_REQUEST, "FOR122-400", "차기 회장은 운영진 계정을 가진 사람 중에서 지정해야 합니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FOR100-500", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/org/forif_backend/domain/product/Product.java
+++ b/src/main/java/org/forif_backend/domain/product/Product.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * 부원이 만든 프로덕트(서비스).
+ * 부원이 만든 서비스.
  * 등록 신청(PENDING/REJECTED)과 승인 후 게시(LIVE/DEV/PAUSED/RETIRED)를 하나의 엔티티로 관리한다.
  */
 @Entity
@@ -138,7 +138,7 @@ public class Product extends BaseTimeEntity {
     }
 
     /**
-     * 운영진의 프로덕트 정보 수정. null인 인자는 변경하지 않는다.
+     * 운영진의 서비스 정보 수정. null인 인자는 변경하지 않는다.
      * slug(서브도메인)와 상태는 별도 경로로만 변경할 수 있다.
      */
     public void updateInfo(String name, String oneLiner, String description, String sourceLabel,

--- a/src/main/java/org/forif_backend/domain/product/ProductMember.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductMember.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import org.forif_backend.common.BaseTimeEntity;
 
 /**
- * 프로덕트 팀원.
+ * 서비스 팀원.
  * 졸업생 등 비가입자도 있을 수 있어 유저 FK 대신 이름을 직접 보관한다.
  */
 @Entity

--- a/src/main/java/org/forif_backend/domain/product/ProductRepository.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductRepository.java
@@ -13,10 +13,10 @@ public interface ProductRepository {
 
     boolean existsBySlug(String slug);
 
-    /** 신청자의 특정 상태 프로덕트 수 (검토 대기 제한 검사용) */
+    /** 신청자의 특정 상태 서비스 수 (검토 대기 제한 검사용) */
     long countByApplicantIdAndStatus(Long userId, ProductStatus status);
 
-    /** 게시된(승인 이후) 프로덕트 목록 — 최신 연도순 */
+    /** 게시된(승인 이후) 서비스 목록 — 최신 연도순 */
     List<Product> findAllPublished();
 
     /** 신청자 기준 전체 신청/게시 목록 — 최신 신청순 */

--- a/src/main/java/org/forif_backend/domain/product/ProductSourceType.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductSourceType.java
@@ -1,6 +1,6 @@
 package org.forif_backend.domain.product;
 
-/** 프로덕트 출처 (스터디 / 해커톤 / 자율 프로젝트) */
+/** 서비스 출처 (스터디 / 해커톤 / 자율 프로젝트) */
 public enum ProductSourceType {
     STUDY,
     HACKATHON,

--- a/src/main/java/org/forif_backend/domain/product/ProductStatus.java
+++ b/src/main/java/org/forif_backend/domain/product/ProductStatus.java
@@ -1,7 +1,7 @@
 package org.forif_backend.domain.product;
 
 /**
- * 프로덕트 상태.
+ * 서비스 상태.
  * PENDING/REJECTED 는 등록 신청 단계, 나머지는 승인 후 게시 상태를 나타낸다.
  */
 public enum ProductStatus {

--- a/src/main/java/org/forif_backend/domain/semester/ActiveSemester.java
+++ b/src/main/java/org/forif_backend/domain/semester/ActiveSemester.java
@@ -1,0 +1,54 @@
+package org.forif_backend.domain.semester;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.forif_backend.common.BaseTimeEntity;
+
+/**
+ * 동아리의 현재 활동 학기.
+ * 시스템 날짜로 계산하지 않고 운영진이 명시적으로 지정한 값을 단일 행으로 보관한다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_active_semester")
+public class ActiveSemester extends BaseTimeEntity {
+
+    /** 항상 1. 활동 학기는 동아리에 하나뿐이므로 단일 행으로 강제한다. */
+    public static final int SINGLETON_ID = 1;
+
+    @Id
+    @Column(name = "active_semester_id")
+    private Integer id;
+
+    @Column(name = "act_year", nullable = false)
+    private int actYear;
+
+    @Column(name = "act_semester", nullable = false)
+    private int actSemester;
+
+    /** 마지막으로 학기를 변경한 운영진 (초기 생성 시 null) */
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    public static ActiveSemester create(int actYear, int actSemester, Long updatedBy) {
+        ActiveSemester semester = new ActiveSemester();
+        semester.id = SINGLETON_ID;
+        semester.actYear = actYear;
+        semester.actSemester = actSemester;
+        semester.updatedBy = updatedBy;
+        return semester;
+    }
+
+    public void change(int actYear, int actSemester, Long updatedBy) {
+        this.actYear = actYear;
+        this.actSemester = actSemester;
+        this.updatedBy = updatedBy;
+    }
+
+    public boolean isSame(int actYear, int actSemester) {
+        return this.actYear == actYear && this.actSemester == actSemester;
+    }
+}

--- a/src/main/java/org/forif_backend/domain/semester/SemesterChangeLog.java
+++ b/src/main/java/org/forif_backend/domain/semester/SemesterChangeLog.java
@@ -1,0 +1,49 @@
+package org.forif_backend.domain.semester;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.forif_backend.common.BaseTimeEntity;
+
+/**
+ * 활동 학기 변경 이력.
+ * 학기 전환은 전 서비스에 영향을 주므로 누가 언제 바꿨는지 남긴다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tb_semester_change_log")
+public class SemesterChangeLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long id;
+
+    @Column(name = "from_year", nullable = false)
+    private int fromYear;
+
+    @Column(name = "from_semester", nullable = false)
+    private int fromSemester;
+
+    @Column(name = "to_year", nullable = false)
+    private int toYear;
+
+    @Column(name = "to_semester", nullable = false)
+    private int toSemester;
+
+    @Column(name = "changed_by", nullable = false)
+    private Long changedBy;
+
+    public static SemesterChangeLog of(int fromYear, int fromSemester,
+                                       int toYear, int toSemester, Long changedBy) {
+        SemesterChangeLog log = new SemesterChangeLog();
+        log.fromYear = fromYear;
+        log.fromSemester = fromSemester;
+        log.toYear = toYear;
+        log.toSemester = toSemester;
+        log.changedBy = changedBy;
+        return log;
+    }
+}

--- a/src/main/java/org/forif_backend/domain/semester/SemesterRepository.java
+++ b/src/main/java/org/forif_backend/domain/semester/SemesterRepository.java
@@ -1,0 +1,12 @@
+package org.forif_backend.domain.semester;
+
+import java.util.Optional;
+
+public interface SemesterRepository {
+
+    Optional<ActiveSemester> findActive();
+
+    ActiveSemester save(ActiveSemester activeSemester);
+
+    void saveChangeLog(SemesterChangeLog log);
+}

--- a/src/main/java/org/forif_backend/domain/study/Study.java
+++ b/src/main/java/org/forif_backend/domain/study/Study.java
@@ -13,7 +13,6 @@ import lombok.Setter;
 import org.forif_backend.common.BaseTimeEntity;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
-import org.forif_backend.common.util.DateUtils;
 import org.forif_backend.domain.user.User;
 import org.forif_backend.web.study.dto.CreateStudyApplyRequest;
 
@@ -133,12 +132,12 @@ public class Study extends BaseTimeEntity {
      * @param mentor 멘토 유저
      * @return 스터디 객체
      */
-    public static Study createPendingStudy(User mentor) {
+    public static Study createPendingStudy(User mentor, int actYear, int actSemester) {
         Study study = new Study();
         study.primaryMentor = mentor;
         study.primaryMentorName = mentor.getUserName();
-        study.actYear = DateUtils.getCurrentYear();
-        study.actSemester = DateUtils.getCurrentSemester();
+        study.actYear = actYear;
+        study.actSemester = actSemester;
 
         return study;
     }

--- a/src/main/java/org/forif_backend/domain/study/StudyUserRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyUserRepository.java
@@ -15,4 +15,10 @@ public interface StudyUserRepository {
     void deleteByUserIdAndStudyId(Long userId, Integer studyId);
 
     boolean existsByUserIdAndStudyYearSemester(Long userId, int year, int semester);
+
+    /** 해당 학기 수강생 수 (수료증 발급 현황 안내용) */
+    long countBySemester(int year, int semester);
+
+    /** 해당 학기 수료증 발급 완료 수 */
+    long countIssuedCertificatesBySemester(int year, int semester);
 }

--- a/src/main/java/org/forif_backend/domain/user/UserApply.java
+++ b/src/main/java/org/forif_backend/domain/user/UserApply.java
@@ -5,7 +5,6 @@ import lombok.*;
 import org.forif_backend.common.BaseTimeEntity;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
-import org.forif_backend.common.util.DateUtils;
 import org.forif_backend.domain.study.Study;
 
 @Entity
@@ -97,11 +96,12 @@ public class UserApply extends BaseTimeEntity {
         this.secondaryIntro = applyReason;
     }
 
-    public static UserApply applyStudy(User applier, Study primaryStudy, String applyReason) {
+    public static UserApply applyStudy(User applier, Study primaryStudy, String applyReason,
+                                       int applyYear, int applySemester) {
         return new UserApply(
                 applier,
-                DateUtils.getCurrentYear(),
-                DateUtils.getCurrentSemester(),
+                applyYear,
+                applySemester,
                 primaryStudy.getId(),
                 applyReason,
                 primaryStudy.getStudyName()

--- a/src/main/java/org/forif_backend/infrastructure/persistence/semester/ActiveSemesterJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/semester/ActiveSemesterJpaRepository.java
@@ -1,0 +1,7 @@
+package org.forif_backend.infrastructure.persistence.semester;
+
+import org.forif_backend.domain.semester.ActiveSemester;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActiveSemesterJpaRepository extends JpaRepository<ActiveSemester, Integer> {
+}

--- a/src/main/java/org/forif_backend/infrastructure/persistence/semester/SemesterChangeLogJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/semester/SemesterChangeLogJpaRepository.java
@@ -1,0 +1,7 @@
+package org.forif_backend.infrastructure.persistence.semester;
+
+import org.forif_backend.domain.semester.SemesterChangeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SemesterChangeLogJpaRepository extends JpaRepository<SemesterChangeLog, Long> {
+}

--- a/src/main/java/org/forif_backend/infrastructure/persistence/semester/SemesterRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/semester/SemesterRepositoryImpl.java
@@ -1,0 +1,32 @@
+package org.forif_backend.infrastructure.persistence.semester;
+
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.domain.semester.ActiveSemester;
+import org.forif_backend.domain.semester.SemesterChangeLog;
+import org.forif_backend.domain.semester.SemesterRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class SemesterRepositoryImpl implements SemesterRepository {
+
+    private final ActiveSemesterJpaRepository activeSemesterJpaRepository;
+    private final SemesterChangeLogJpaRepository semesterChangeLogJpaRepository;
+
+    @Override
+    public Optional<ActiveSemester> findActive() {
+        return activeSemesterJpaRepository.findById(ActiveSemester.SINGLETON_ID);
+    }
+
+    @Override
+    public ActiveSemester save(ActiveSemester activeSemester) {
+        return activeSemesterJpaRepository.save(activeSemester);
+    }
+
+    @Override
+    public void saveChangeLog(SemesterChangeLog log) {
+        semesterChangeLogJpaRepository.save(log);
+    }
+}

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserJpaRepository.java
@@ -25,6 +25,19 @@ public interface StudyUserJpaRepository extends JpaRepository<StudyUser, StudyUs
     @Query("SELECT su FROM StudyUser su WHERE su.user.id = :userId")
     List<StudyUser> findAllByUserId(@Param("userId") Long userId);
 
+    @Query("""
+            SELECT COUNT(su) FROM StudyUser su
+            WHERE su.study.actYear = :year AND su.study.actSemester = :semester
+            """)
+    long countBySemester(@Param("year") int year, @Param("semester") int semester);
+
+    @Query("""
+            SELECT COUNT(su) FROM StudyUser su
+            WHERE su.study.actYear = :year AND su.study.actSemester = :semester
+              AND su.certificateStatus = 1
+            """)
+    long countIssuedCertificatesBySemester(@Param("year") int year, @Param("semester") int semester);
+
     void deleteByStudyId(Integer studyId);
 
     void deleteByUserIdAndStudyId(Long userId, Integer studyId);

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserRepositoryImpl.java
@@ -40,6 +40,16 @@ public class StudyUserRepositoryImpl implements StudyUserRepository {
     }
 
     @Override
+    public long countBySemester(int year, int semester) {
+        return studyUserJpaRepository.countBySemester(year, semester);
+    }
+
+    @Override
+    public long countIssuedCertificatesBySemester(int year, int semester) {
+        return studyUserJpaRepository.countIssuedCertificatesBySemester(year, semester);
+    }
+
+    @Override
     public boolean existsByUserIdAndStudyYearSemester(Long userId, int year, int semester) {
         return studyUserJpaRepository.existsByUserIdAndStudyYearSemester(userId, year, semester);
     }

--- a/src/main/java/org/forif_backend/web/product/AdminProductController.java
+++ b/src/main/java/org/forif_backend/web/product/AdminProductController.java
@@ -100,7 +100,7 @@ public class AdminProductController {
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
     }
 
-    @Operation(summary = "서비스 삭제", description = "서비스(신청 포함)를 삭제합니다.")
+    @Operation(summary = "서비스 삭제", description = "서비스를 삭제합니다. 검토 대기·반려 상태의 등록 신청도 같은 방식으로 지울 수 있으며, 삭제하면 되돌릴 수 없습니다.")
     @DeleteMapping("/{productId}")
     public ResponseEntity<ApiResponse<Void>> deleteProduct(
             @Parameter(description = "서비스 ID") @PathVariable Integer productId

--- a/src/main/java/org/forif_backend/web/product/AdminProductController.java
+++ b/src/main/java/org/forif_backend/web/product/AdminProductController.java
@@ -26,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Tag(name = "프로덕트 관리 (운영진)", description = "프로덕트 등록 신청 검토 및 게시 관리 API")
+@Tag(name = "서비스 관리 (운영진)", description = "서비스 등록 신청 검토 및 게시 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/products")
@@ -35,7 +35,7 @@ public class AdminProductController {
 
     private final ProductService productService;
 
-    @Operation(summary = "프로덕트 전체 목록 (운영진)", description = "검토 대기 신청을 포함한 모든 프로덕트를 조회합니다.")
+    @Operation(summary = "서비스 전체 목록 (운영진)", description = "검토 대기 신청을 포함한 모든 서비스를 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<List<AdminProductResponse>>> getAllProducts() {
         return ResponseEntity.ok(
@@ -45,7 +45,7 @@ public class AdminProductController {
     @Operation(summary = "등록 신청 승인", description = "검토 대기 신청을 승인해 서비스 중 상태로 게시합니다.")
     @PatchMapping("/{productId}/approve")
     public ResponseEntity<ApiResponse<Void>> approveProduct(
-            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId
+            @Parameter(description = "서비스 ID") @PathVariable Integer productId
     ) {
         productService.approveProduct(productId);
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
@@ -54,37 +54,37 @@ public class AdminProductController {
     @Operation(summary = "등록 신청 반려", description = "검토 대기 신청을 사유와 함께 반려합니다.")
     @PatchMapping("/{productId}/reject")
     public ResponseEntity<ApiResponse<Void>> rejectProduct(
-            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @Parameter(description = "서비스 ID") @PathVariable Integer productId,
             @Valid @RequestBody RejectProductRequest request
     ) {
         productService.rejectProduct(productId, request.getRejectReason());
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
     }
 
-    @Operation(summary = "게시 상태 변경", description = "게시된 프로덕트의 상태(LIVE/DEV/PAUSED/RETIRED)를 변경합니다.")
+    @Operation(summary = "게시 상태 변경", description = "게시된 서비스의 상태(LIVE/DEV/PAUSED/RETIRED)를 변경합니다.")
     @PatchMapping("/{productId}/status")
     public ResponseEntity<ApiResponse<Void>> changeProductStatus(
-            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @Parameter(description = "서비스 ID") @PathVariable Integer productId,
             @Valid @RequestBody UpdateProductStatusRequest request
     ) {
         productService.changeProductStatus(productId, request.getStatus());
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
     }
 
-    @Operation(summary = "프로덕트 정보 수정", description = "프로덕트의 소개·링크·기술 스택 등을 수정합니다. 전달하지 않은 필드는 변경되지 않습니다.")
+    @Operation(summary = "서비스 정보 수정", description = "서비스의 소개·링크·기술 스택 등을 수정합니다. 전달하지 않은 필드는 변경되지 않습니다.")
     @PatchMapping("/{productId}")
     public ResponseEntity<ApiResponse<AdminProductResponse>> updateProduct(
-            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @Parameter(description = "서비스 ID") @PathVariable Integer productId,
             @Valid @RequestBody UpdateProductRequest request
     ) {
         ProductInfo info = productService.updateProduct(productId, request.toCommand());
         return ResponseEntity.ok(ApiResponse.success(AdminProductResponse.from(info)));
     }
 
-    @Operation(summary = "썸네일 등록·교체", description = "프로덕트 대표 이미지를 등록하거나 교체합니다. 5MB 이하 이미지 파일만 허용됩니다.")
+    @Operation(summary = "썸네일 등록·교체", description = "서비스 대표 이미지를 등록하거나 교체합니다. 5MB 이하 이미지 파일만 허용됩니다.")
     @PostMapping(value = "/{productId}/thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ThumbnailResponse>> updateThumbnail(
-            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId,
+            @Parameter(description = "서비스 ID") @PathVariable Integer productId,
             @RequestPart("file") MultipartFile file
     ) {
         String thumbnailUrl = productService.updateThumbnail(productId, file);
@@ -94,16 +94,16 @@ public class AdminProductController {
     @Operation(summary = "썸네일 삭제", description = "등록된 대표 이미지를 제거합니다. 제거하면 기본 플레이스홀더가 표시됩니다.")
     @DeleteMapping("/{productId}/thumbnail")
     public ResponseEntity<ApiResponse<Void>> deleteThumbnail(
-            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId
+            @Parameter(description = "서비스 ID") @PathVariable Integer productId
     ) {
         productService.deleteThumbnail(productId);
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
     }
 
-    @Operation(summary = "프로덕트 삭제", description = "프로덕트(신청 포함)를 삭제합니다.")
+    @Operation(summary = "서비스 삭제", description = "서비스(신청 포함)를 삭제합니다.")
     @DeleteMapping("/{productId}")
     public ResponseEntity<ApiResponse<Void>> deleteProduct(
-            @Parameter(description = "프로덕트 ID") @PathVariable Integer productId
+            @Parameter(description = "서비스 ID") @PathVariable Integer productId
     ) {
         productService.deleteProduct(productId);
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));

--- a/src/main/java/org/forif_backend/web/product/ProductController.java
+++ b/src/main/java/org/forif_backend/web/product/ProductController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "프로덕트", description = "부원 프로덕트 쇼케이스 및 등록 신청 API")
+@Tag(name = "서비스", description = "부원 서비스 쇼케이스 및 등록 신청 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/products")
@@ -26,14 +26,14 @@ public class ProductController {
 
     private final ProductService productService;
 
-    @Operation(summary = "프로덕트 목록 조회", description = "게시된(승인된) 프로덕트 목록을 조회합니다. 인증 없이 접근 가능합니다.")
+    @Operation(summary = "서비스 목록 조회", description = "게시된(승인된) 서비스 목록을 조회합니다. 인증 없이 접근 가능합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<List<ProductResponse>>> getProducts() {
         List<ProductInfo> products = productService.getPublishedProducts();
         return ResponseEntity.ok(ApiResponse.success(ProductResponse.fromList(products)));
     }
 
-    @Operation(summary = "내 프로덕트 신청 현황", description = "로그인한 부원의 프로덕트 등록 신청 목록과 검토 결과를 조회합니다.")
+    @Operation(summary = "내 서비스 신청 현황", description = "로그인한 부원의 서비스 등록 신청 목록과 검토 결과를 조회합니다.")
     @GetMapping("/applications/me")
     public ResponseEntity<ApiResponse<List<ProductApplicationResponse>>> getMyApplications(
             @AuthenticationPrincipal Long userId
@@ -42,7 +42,7 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.fromList(applications)));
     }
 
-    @Operation(summary = "프로덕트 등록 신청", description = "부원이 직접 만든 서비스의 등록을 신청합니다. 운영진 승인 후 목록에 게시됩니다.")
+    @Operation(summary = "서비스 등록 신청", description = "부원이 직접 만든 서비스의 등록을 신청합니다. 운영진 승인 후 목록에 게시됩니다.")
     @PostMapping("/applications")
     public ResponseEntity<ApiResponse<ProductApplicationResponse>> applyProduct(
             @AuthenticationPrincipal Long userId,
@@ -52,10 +52,10 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.from(info)));
     }
 
-    @Operation(summary = "프로덕트 상세 조회", description = "게시된 프로덕트의 상세 정보를 조회합니다. 인증 없이 접근 가능합니다.")
+    @Operation(summary = "서비스 상세 조회", description = "게시된 서비스의 상세 정보를 조회합니다. 인증 없이 접근 가능합니다.")
     @GetMapping("/{slug}")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
-            @Parameter(description = "프로덕트 슬러그(서브도메인)") @PathVariable String slug
+            @Parameter(description = "서비스 슬러그(서브도메인)") @PathVariable String slug
     ) {
         ProductInfo product = productService.getPublishedProduct(slug);
         return ResponseEntity.ok(ApiResponse.success(ProductDetailResponse.from(product)));

--- a/src/main/java/org/forif_backend/web/product/ProductController.java
+++ b/src/main/java/org/forif_backend/web/product/ProductController.java
@@ -33,7 +33,7 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.success(ProductResponse.fromList(products)));
     }
 
-    @Operation(summary = "내 서비스 신청 현황", description = "로그인한 부원의 서비스 등록 신청 목록과 검토 결과를 조회합니다.")
+    @Operation(summary = "내 서비스 등록 신청 현황", description = "로그인한 부원의 서비스 등록 신청 목록과 검토 결과를 조회합니다.")
     @GetMapping("/applications/me")
     public ResponseEntity<ApiResponse<List<ProductApplicationResponse>>> getMyApplications(
             @AuthenticationPrincipal Long userId

--- a/src/main/java/org/forif_backend/web/semester/AdminSemesterController.java
+++ b/src/main/java/org/forif_backend/web/semester/AdminSemesterController.java
@@ -24,7 +24,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "학기 관리 (회장단)", description = "동아리 활동 학기 전환 API")
+@Tag(name = "학기 관리 (회장)", description = "동아리 활동 학기 전환 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/semesters")
@@ -43,14 +43,14 @@ public class AdminSemesterController {
             @Parameter(description = "대상 연도") @RequestParam int actYear,
             @Parameter(description = "대상 학기 (1 또는 2)") @RequestParam int actSemester
     ) {
-        staffAccountService.requirePresidentTeam(userId);
+        staffAccountService.requirePresident(userId);
         SemesterChangePreview preview = semesterService.preview(actYear, actSemester);
         return ResponseEntity.ok(ApiResponse.success(SemesterChangePreviewResponse.from(preview)));
     }
 
     @Operation(summary = "활동 학기 변경",
             description = """
-                    동아리의 현재 활동 학기를 변경합니다. 회장단만 사용할 수 있습니다.
+                    동아리의 현재 활동 학기를 변경합니다. 회장직 인수인계가 함께 일어나므로 회장만 사용할 수 있습니다.
 
                     변경 후 새로 생성되는 스터디 개설 신청·수강 신청이 이 학기로 기록되고,
                     목록·마이페이지의 현재 학기 판정이 바뀝니다. 이미 저장된 데이터는 영향받지 않습니다.
@@ -63,7 +63,7 @@ public class AdminSemesterController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ChangeSemesterRequest request
     ) {
-        staffAccountService.requirePresidentTeam(userId);
+        staffAccountService.requirePresident(userId);
         SemesterInfo changed = semesterTransitionService.transition(
                 request.getActYear(), request.getActSemester(),
                 request.getNextPresidentUserId(), userId);

--- a/src/main/java/org/forif_backend/web/semester/AdminSemesterController.java
+++ b/src/main/java/org/forif_backend/web/semester/AdminSemesterController.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.SemesterTransitionService;
 import org.forif_backend.application.semester.dto.SemesterChangePreview;
 import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.application.staff.StaffAccountService;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminSemesterController {
 
     private final SemesterService semesterService;
+    private final SemesterTransitionService semesterTransitionService;
     private final StaffAccountService staffAccountService;
 
     @Operation(summary = "학기 전환 미리보기",
@@ -52,6 +54,9 @@ public class AdminSemesterController {
 
                     변경 후 새로 생성되는 스터디 개설 신청·수강 신청이 이 학기로 기록되고,
                     목록·마이페이지의 현재 학기 판정이 바뀝니다. 이미 저장된 데이터는 영향받지 않습니다.
+
+                    차기 회장 지정이 필수이며, 운영진(ADMIN) 계정을 가진 사람만 지정할 수 있습니다.
+                    현 회장 본인을 지정하면 연임으로 처리되어 권한이 그대로 유지됩니다.
                     """)
     @PatchMapping("/current")
     public ResponseEntity<ApiResponse<SemesterResponse>> changeCurrentSemester(
@@ -59,11 +64,9 @@ public class AdminSemesterController {
             @Valid @RequestBody ChangeSemesterRequest request
     ) {
         staffAccountService.requirePresidentTeam(userId);
-        SemesterInfo changed = semesterService.changeActiveWithRollover(
-                request.getActYear(),
-                request.getActSemester(),
-                Boolean.TRUE.equals(request.getCopyTeamMembers()),
-                userId);
+        SemesterInfo changed = semesterTransitionService.transition(
+                request.getActYear(), request.getActSemester(),
+                request.getNextPresidentUserId(), userId);
         return ResponseEntity.ok(ApiResponse.success(SemesterResponse.from(changed)));
     }
 
@@ -80,7 +83,8 @@ public class AdminSemesterController {
         @Max(2)
         private Integer actSemester;
 
-        /** true면 현재 학기 운영진 명단을 새 학기로 복제한다 */
-        private Boolean copyTeamMembers;
+        /** 차기 회장 학번 (필수). 연임이면 현 회장 본인을 지정한다. */
+        @NotNull
+        private Long nextPresidentUserId;
     }
 }

--- a/src/main/java/org/forif_backend/web/semester/AdminSemesterController.java
+++ b/src/main/java/org/forif_backend/web/semester/AdminSemesterController.java
@@ -1,0 +1,86 @@
+package org.forif_backend.web.semester;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterChangePreview;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.application.staff.StaffAccountService;
+import org.forif_backend.common.dto.response.ApiResponse;
+import org.forif_backend.web.semester.dto.SemesterChangePreviewResponse;
+import org.forif_backend.web.semester.dto.SemesterResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "학기 관리 (회장단)", description = "동아리 활동 학기 전환 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/semesters")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminSemesterController {
+
+    private final SemesterService semesterService;
+    private final StaffAccountService staffAccountService;
+
+    @Operation(summary = "학기 전환 미리보기",
+            description = "대상 학기로 전환했을 때의 영향(운영진 명단·해커톤 준비 여부)을 확인합니다.")
+    @GetMapping("/preview")
+    public ResponseEntity<ApiResponse<SemesterChangePreviewResponse>> preview(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "대상 연도") @RequestParam int actYear,
+            @Parameter(description = "대상 학기 (1 또는 2)") @RequestParam int actSemester
+    ) {
+        staffAccountService.requirePresidentTeam(userId);
+        SemesterChangePreview preview = semesterService.preview(actYear, actSemester);
+        return ResponseEntity.ok(ApiResponse.success(SemesterChangePreviewResponse.from(preview)));
+    }
+
+    @Operation(summary = "활동 학기 변경",
+            description = """
+                    동아리의 현재 활동 학기를 변경합니다. 회장단만 사용할 수 있습니다.
+
+                    변경 후 새로 생성되는 스터디 개설 신청·수강 신청이 이 학기로 기록되고,
+                    목록·마이페이지의 현재 학기 판정이 바뀝니다. 이미 저장된 데이터는 영향받지 않습니다.
+                    """)
+    @PatchMapping("/current")
+    public ResponseEntity<ApiResponse<SemesterResponse>> changeCurrentSemester(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ChangeSemesterRequest request
+    ) {
+        staffAccountService.requirePresidentTeam(userId);
+        SemesterInfo changed = semesterService.changeActiveWithRollover(
+                request.getActYear(),
+                request.getActSemester(),
+                Boolean.TRUE.equals(request.getCopyTeamMembers()),
+                userId);
+        return ResponseEntity.ok(ApiResponse.success(SemesterResponse.from(changed)));
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class ChangeSemesterRequest {
+        @NotNull
+        @Min(2018)
+        private Integer actYear;
+
+        @NotNull
+        @Min(1)
+        @Max(2)
+        private Integer actSemester;
+
+        /** true면 현재 학기 운영진 명단을 새 학기로 복제한다 */
+        private Boolean copyTeamMembers;
+    }
+}

--- a/src/main/java/org/forif_backend/web/semester/SemesterController.java
+++ b/src/main/java/org/forif_backend/web/semester/SemesterController.java
@@ -1,0 +1,40 @@
+package org.forif_backend.web.semester;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.common.dto.response.ApiResponse;
+import org.forif_backend.web.semester.dto.SemesterResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "학기", description = "동아리 활동 학기 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/semesters")
+public class SemesterController {
+
+    private final SemesterService semesterService;
+
+    @Operation(summary = "현재 활동 학기 조회",
+            description = "운영진이 지정한 현재 활동 학기를 조회합니다. 인증 없이 접근 가능합니다.")
+    @GetMapping("/current")
+    public ResponseEntity<ApiResponse<SemesterResponse>> getCurrentSemester() {
+        SemesterInfo active = semesterService.getActive();
+        return ResponseEntity.ok(ApiResponse.success(SemesterResponse.from(active)));
+    }
+
+    @Operation(summary = "선택 가능한 학기 목록",
+            description = "동아리 창립 학기부터 다음 학기까지의 목록을 최신순으로 조회합니다. 인증 없이 접근 가능합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SemesterResponse>>> getSemesters() {
+        List<SemesterInfo> semesters = semesterService.getSelectableSemesters();
+        return ResponseEntity.ok(ApiResponse.success(SemesterResponse.fromList(semesters)));
+    }
+}

--- a/src/main/java/org/forif_backend/web/semester/dto/SemesterChangePreviewResponse.java
+++ b/src/main/java/org/forif_backend/web/semester/dto/SemesterChangePreviewResponse.java
@@ -1,0 +1,23 @@
+package org.forif_backend.web.semester.dto;
+
+import org.forif_backend.application.semester.dto.SemesterChangePreview;
+
+public record SemesterChangePreviewResponse(
+        SemesterResponse current,
+        SemesterResponse target,
+        int targetTeamMemberCount,
+        int currentTeamMemberCount,
+        boolean needsTeamCopy,
+        boolean targetHackathonExists
+) {
+    public static SemesterChangePreviewResponse from(SemesterChangePreview preview) {
+        return new SemesterChangePreviewResponse(
+                SemesterResponse.from(preview.current()),
+                SemesterResponse.from(preview.target()),
+                preview.targetTeamMemberCount(),
+                preview.currentTeamMemberCount(),
+                preview.needsTeamCopy(),
+                preview.targetHackathonExists()
+        );
+    }
+}

--- a/src/main/java/org/forif_backend/web/semester/dto/SemesterChangePreviewResponse.java
+++ b/src/main/java/org/forif_backend/web/semester/dto/SemesterChangePreviewResponse.java
@@ -6,18 +6,22 @@ public record SemesterChangePreviewResponse(
         SemesterResponse current,
         SemesterResponse target,
         int targetTeamMemberCount,
-        int currentTeamMemberCount,
-        boolean needsTeamCopy,
-        boolean targetHackathonExists
+        boolean needsTeamSetup,
+        boolean targetHackathonExists,
+        long currentMemberCount,
+        long currentCertificateIssuedCount,
+        boolean hasPendingCertificates
 ) {
     public static SemesterChangePreviewResponse from(SemesterChangePreview preview) {
         return new SemesterChangePreviewResponse(
                 SemesterResponse.from(preview.current()),
                 SemesterResponse.from(preview.target()),
                 preview.targetTeamMemberCount(),
-                preview.currentTeamMemberCount(),
-                preview.needsTeamCopy(),
-                preview.targetHackathonExists()
+                preview.needsTeamSetup(),
+                preview.targetHackathonExists(),
+                preview.currentMemberCount(),
+                preview.currentCertificateIssuedCount(),
+                preview.hasPendingCertificates()
         );
     }
 }

--- a/src/main/java/org/forif_backend/web/semester/dto/SemesterResponse.java
+++ b/src/main/java/org/forif_backend/web/semester/dto/SemesterResponse.java
@@ -1,0 +1,19 @@
+package org.forif_backend.web.semester.dto;
+
+import org.forif_backend.application.semester.dto.SemesterInfo;
+
+import java.util.List;
+
+public record SemesterResponse(
+        int actYear,
+        int actSemester,
+        String label
+) {
+    public static SemesterResponse from(SemesterInfo info) {
+        return new SemesterResponse(info.actYear(), info.actSemester(), info.label());
+    }
+
+    public static List<SemesterResponse> fromList(List<SemesterInfo> infos) {
+        return infos.stream().map(SemesterResponse::from).toList();
+    }
+}

--- a/src/main/java/org/forif_backend/web/team/ForifTeamController.java
+++ b/src/main/java/org/forif_backend/web/team/ForifTeamController.java
@@ -5,11 +5,19 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.application.team.ForifTeamService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.forif_backend.application.staff.StaffAccountService;
 import org.forif_backend.common.dto.response.ApiResponse;
 import org.forif_backend.web.team.dto.ForifTeamResponse;
 import org.forif_backend.web.team.dto.UpdateForifTeamRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,6 +28,7 @@ import java.util.List;
 public class ForifTeamController {
 
     private final ForifTeamService forifTeamService;
+    private final StaffAccountService staffAccountService;
 
     @Operation(summary = "전체 운영진 이력 조회")
     @GetMapping("/api/v1/forif-team")
@@ -36,6 +45,48 @@ public class ForifTeamController {
     ) {
         List<ForifTeamResponse> response = forifTeamService.getMembersByYearAndSemester(year, semester);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "운영진 명단 추가 (회장단 전용)",
+            description = """
+                    운영진 명단(홈페이지 운영진 소개)에 부원을 추가합니다.
+
+                    학기를 지정하지 않으면 현재 활동 학기에 추가됩니다.
+                    학기가 바뀌면 명단은 자동으로 이어지지 않으므로, 새 학기마다 이 API로 지정해야 합니다.
+                    """)
+    @PostMapping("/api/v1/admin/forif-team")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<ForifTeamResponse>> addMember(
+            @AuthenticationPrincipal Long requesterId,
+            @Valid @RequestBody AddForifTeamRequest request
+    ) {
+        staffAccountService.requirePresidentTeam(requesterId);
+        ForifTeamResponse response = forifTeamService.addMember(
+                request.getUserId(),
+                request.getActYear(),
+                request.getActSemester(),
+                request.getClubDepartment(),
+                request.getUserTitle()
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class AddForifTeamRequest {
+        @NotNull
+        private Long userId;
+
+        /** 미지정 시 현재 활동 학기 */
+        private Integer actYear;
+        private Integer actSemester;
+
+        @NotBlank
+        private String clubDepartment;
+
+        /** 회장/부회장/팀장 등 직책 (선택) */
+        private String userTitle;
     }
 
     @Operation(summary = "운영진 이력 수정 (어드민 전용)", description = "직책, 팀, 소개 등 운영진 프로필 정보를 수정합니다.")


### PR DESCRIPTION
## 배경

학기를 날짜로 계산하고 있어 백엔드 `month<=7`, admin `month<=6`, web `month>=2&&<=7` 세 곳의 기준이 서로 달랐습니다. 개강 전 다음 학기 스터디를 열거나 종강 후 지난 학기를 노출해야 하는 경우 실제 활동 학기와 달력이 어긋나기도 했습니다.

활동 학기를 DB 상태로 두고 운영진이 직접 전환하도록 바꿉니다.

## 변경 사항

**학기 도메인 신규**
- `tb_active_semester` (단일 행), `tb_semester_change_log` (전환 이력)
- `SemesterService` — 활동 학기 조회/변경, 선택 가능 학기 목록 생성 (2018-1 ~ 다음 학기)
- `SemesterTransitionService` — 학기 전환 + 회장 인수인계 (순환 참조 회피용 분리)

**API**
| 메서드 | 경로 | 권한 |
|---|---|---|
| GET | `/api/v1/semesters/current` | 공개 |
| GET | `/api/v1/semesters` | 공개 |
| GET | `/api/v1/admin/semesters/preview` | 회장 |
| PATCH | `/api/v1/admin/semesters/current` | 회장 |
| POST | `/api/v1/admin/forif-team` | 회장단 |

**회장 인수인계**
학기 전환 시 차기 회장 지정이 필수입니다. 운영진(ADMIN) 계정을 가진 사람만 지정할 수 있고, 본인을 지정하면 연임으로 권한이 유지됩니다. 다른 사람을 지정하면 전환과 동시에 회장 권한이 넘어가고 전 회장은 일반 운영진이 됩니다.

인수인계가 회장 고유 권한이라 엔드포인트도 회장 전용입니다. (부회장을 허용하면 학기만 바뀌고 인수인계 단계에서 롤백되어 403만 반복됩니다.)

**날짜 계산 제거**
`DateUtils` 호출 7곳을 `semesterService.getActive()`로 교체했습니다. `Study.createPendingStudy`, `UserApply.applyStudy`는 학기를 파라미터로 받습니다.

**부수 수정**
- 서브도메인 오류 메시지에 실제 거절 사유(하이픈 시작·끝, 예약어) 추가
- 화면·API 문서의 "프로덕트" → "서비스" (경로·식별자·DB는 유지)

## ⚠️ 배포 시 주의

dev·운영 서버는 `ddl-auto: validate`라 테이블이 자동 생성되지 않습니다. **JAR 교체 전에** `docs/create-semester-tables.sql`을 실행해야 합니다. 초기 행 `(1, 2026, 1)`이 함께 들어갑니다.

## 확인한 것

| 시나리오 | 결과 |
|---|---|
| 차기 회장 미지정 전환 | 거부 (FOR003-400) |
| 운영진 계정 없는 부원 지정 | 거부 (FOR122-400) |
| 인수인계 (2011031088 → 2024097956) | 권한 이동 확인, 전 회장 403 / 신임 회장 200 |
| 연임 (자기 자신 지정) | 전환 + 권한 유지 |
| 부회장이 전환 시도 | 진입 단계에서 거부 |
| 수료증 현황 집계 | 26-1 수강 190명 중 4명 발급, `has_pending_certificates: true` |

`./gradlew test` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)