### PR TITLE
feat(admin): 멘토 학기별 조회 500에러 해결

### DIFF
--- a/src/main/java/org/forif_backend/infrastructure/persistence/staff/StaffAccountQueryRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/staff/StaffAccountQueryRepository.java
@@ -1,6 +1,7 @@
 package org.forif_backend.infrastructure.persistence.staff;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.forif_backend.domain.staff.QStaffAccount;
@@ -91,16 +92,11 @@ public class StaffAccountQueryRepository {
 
     public List<StaffAccount> searchMentorsByYearSemester(int year, int semester, Long cursor, int size, String search) {
         return queryFactory
-                .selectFrom(staffAccount).distinct()
+                .selectFrom(staffAccount)
                 .join(staffAccount.user).fetchJoin()
-                .join(study).on(
-                        study.primaryMentor.id.eq(staffAccount.user.id)
-                                .or(study.secondaryMentor.id.eq(staffAccount.user.id))
-                )
                 .where(
                         staffAccount.role.eq(StaffRole.MENTOR),
-                        study.actYear.eq(year),
-                        study.actSemester.eq(semester),
+                        mentorsStudyInSemester(year, semester),
                         cursorLt(cursor),
                         searchKeyword(search)
                 )
@@ -111,16 +107,11 @@ public class StaffAccountQueryRepository {
 
     public long countMentorsByYearSemester(int year, int semester, String search) {
         Long count = queryFactory
-                .select(staffAccount.countDistinct())
+                .select(staffAccount.count())
                 .from(staffAccount)
-                .join(study).on(
-                        study.primaryMentor.id.eq(staffAccount.user.id)
-                                .or(study.secondaryMentor.id.eq(staffAccount.user.id))
-                )
                 .where(
                         staffAccount.role.eq(StaffRole.MENTOR),
-                        study.actYear.eq(year),
-                        study.actSemester.eq(semester),
+                        mentorsStudyInSemester(year, semester),
                         searchKeyword(search)
                 )
                 .fetchOne();
@@ -157,16 +148,11 @@ public class StaffAccountQueryRepository {
 
     public List<StaffAccount> searchMentorsByYearSemesterWithOffset(int year, int semester, int page, int size, String search) {
         return queryFactory
-                .selectFrom(staffAccount).distinct()
+                .selectFrom(staffAccount)
                 .join(staffAccount.user).fetchJoin()
-                .join(study).on(
-                        study.primaryMentor.id.eq(staffAccount.user.id)
-                                .or(study.secondaryMentor.id.eq(staffAccount.user.id))
-                )
                 .where(
                         staffAccount.role.eq(StaffRole.MENTOR),
-                        study.actYear.eq(year),
-                        study.actSemester.eq(semester),
+                        mentorsStudyInSemester(year, semester),
                         searchKeyword(search)
                 )
                 .orderBy(staffAccount.user.id.desc())
@@ -203,6 +189,19 @@ public class StaffAccountQueryRepository {
             return null;
         }
         return staffAccount.user.id.lt(cursor.longValue());
+    }
+
+    private BooleanExpression mentorsStudyInSemester(int year, int semester) {
+        return JPAExpressions
+                .selectOne()
+                .from(study)
+                .where(
+                        study.actYear.eq(year),
+                        study.actSemester.eq(semester),
+                        study.primaryMentor.id.eq(staffAccount.user.id)
+                                .or(study.secondaryMentor.id.eq(staffAccount.user.id))
+                )
+                .exists();
     }
 
     private BooleanExpression cursorLt(Long cursor) {


### PR DESCRIPTION
## 📌 PR 제목

[Fix] 학기별 멘토 조회 500 오류 수정

---

## ✨ 변경사항

- 학기별 멘토 조회 쿼리에서 `Study` 직접 조인을 `EXISTS` 조건으로 변경
- 데이터 유무와 관계없이 발생하던 500 오류 해결

---

## ⚠️ 유의해야 할 점

- API 경로, 요청 파라미터, 응답 형식은 변경되지 않았습니다.
- 해당 학기에 멘토 데이터가 없으면 정상적으로 빈 목록이 반환됩니다.