### PR TITLE
feat(web): 회원가입할 때 accessToken 넘기도록 구조 변경

### DIFF
--- a/src/main/java/org/forif_backend/web/user/UserController.java
+++ b/src/main/java/org/forif_backend/web/user/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
 
     /**
      * 부원 회원가입
-     * 프론트엔드에서 Google OAuth로 획득한 이메일을 함께 전송
+     * 프론트엔드에서 전달한 Google OAuth Access Token으로 이메일을 검증합니다.
      */
     @Operation(summary = "부원 회원가입", description = "Google OAuth 이메일 인증 후 신규 부원을 등록합니다. Refresh Token은 HttpOnly 쿠키로 발급됩니다.")
     @PostMapping("/signup")
@@ -52,16 +52,19 @@ public class UserController {
             @RequestBody UserSignUpRequest request,
             HttpServletResponse httpResponse
     ) {
-        // 1. Web DTO → Application Command 변환
-        UserSignUpCommand command = UserDtoMapper.toCommand(request);
+        // 1. Google에서 이메일 가져오기
+        String email = userService.getEmailFromGoogleToken(request.accessToken());
 
-        // 2. Service 호출
+        // 2. Web DTO → Application Command 변환
+        UserSignUpCommand command = UserDtoMapper.toCommand(request, email);
+
+        // 3. Service 호출
         UserSignUpResult result = userService.userSignUp(command);
 
-        // 3. Refresh Token을 HttpOnly 쿠키로 설정
+        // 4. Refresh Token을 HttpOnly 쿠키로 설정
         CookieUtils.addRefreshTokenCookie(httpResponse, result.refreshToken());
 
-        // 4. Application Result → Web DTO 변환 (refreshToken 제외)
+        // 5. Application Result → Web DTO 변환 (refreshToken 제외)
         UserSignUpResponse response = UserDtoMapper.toResponse(result);
 
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -70,7 +73,7 @@ public class UserController {
     /**
      * 부원 로그인
      */
-    @Operation(summary = "부원 로그인", description = "Google OAuth Access Token으로 로그인합니다. Refresh Token은 HttpOnly 쿠키로 발급됩니다.")
+    @Operation(summary = "부원 로그인", description = "Google OAuth Access Token으로 가입 상태를 확인하고, 가입된 부원에게 Refresh Token을 HttpOnly 쿠키로 발급합니다.")
     @PostMapping("/signin")
     public ResponseEntity<ApiResponse<UserSignInResponse>> userSignIn(
             @RequestBody UserSignInRequest request,

--- a/src/main/java/org/forif_backend/web/user/UserDtoMapper.java
+++ b/src/main/java/org/forif_backend/web/user/UserDtoMapper.java
@@ -15,11 +15,11 @@ public class UserDtoMapper {
     /**
      * Web DTO → Application Command
      */
-    public static UserSignUpCommand toCommand(UserSignUpRequest request) {
+    public static UserSignUpCommand toCommand(UserSignUpRequest request, String email) {
         return new UserSignUpCommand(
             request.studentId(),
             request.userName(),
-            request.email(),
+            email,
             request.phoneNum(),
             request.department()
         );

--- a/src/main/java/org/forif_backend/web/user/dto/UserSignUpRequest.java
+++ b/src/main/java/org/forif_backend/web/user/dto/UserSignUpRequest.java
@@ -3,7 +3,7 @@ package org.forif_backend.web.user.dto;
 public record UserSignUpRequest(
     Long studentId,     // 학번
     String userName,    // 이름
-    String email,       // 이메일 (프론트에서 Google OAuth로 획득)
+    String accessToken, // Google OAuth Access Token
     String phoneNum,    // 전화번호
     String department   // 학과
 ) {

--- a/src/test/java/org/forif_backend/web/user/UserControllerTest.java
+++ b/src/test/java/org/forif_backend/web/user/UserControllerTest.java
@@ -44,7 +44,7 @@ class UserControllerTest {
         UserSignUpRequest request = new UserSignUpRequest(
                 20241234L,
                 "테스트유저",
-                "test@hanyang.ac.kr",
+                "mock-google-access-token",
                 "010-1234-5678",
                 "컴퓨터공학과"
         );
@@ -71,7 +71,7 @@ class UserControllerTest {
         UserSignUpRequest firstRequest = new UserSignUpRequest(
                 20241234L,
                 "테스트유저1",
-                "duplicate@hanyang.ac.kr",
+                "mock-duplicate-google-access-token",
                 "010-1234-5678",
                 "컴퓨터공학과"
         );
@@ -84,7 +84,7 @@ class UserControllerTest {
         UserSignUpRequest duplicateRequest = new UserSignUpRequest(
                 20245678L,
                 "테스트유저2",
-                "duplicate@hanyang.ac.kr",
+                "mock-duplicate-google-access-token",
                 "010-9876-5432",
                 "전자공학과"
         );
@@ -100,13 +100,13 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("로그인 성공 테스트 (Google OAuth 없이 이메일로)")
+    @DisplayName("로그인 성공 테스트 (Google OAuth 모킹 필요)")
     void userSignInSuccess() throws Exception {
         // given - 먼저 회원가입
         UserSignUpRequest signUpRequest = new UserSignUpRequest(
                 20241234L,
                 "로그인테스트",
-                "signin@hanyang.ac.kr",
+                "mock-signin-google-access-token",
                 "010-1234-5678",
                 "컴퓨터공학과"
         );
@@ -130,7 +130,7 @@ class UserControllerTest {
         UserSignUpRequest signUpRequest = new UserSignUpRequest(
                 20241234L,
                 "리프레시테스트",
-                "refresh@hanyang.ac.kr",
+                "mock-refresh-google-access-token",
                 "010-1234-5678",
                 "컴퓨터공학과"
         );
@@ -169,7 +169,7 @@ class UserControllerTest {
         UserSignUpRequest signUpRequest = new UserSignUpRequest(
                 20241234L,
                 "로그아웃테스트",
-                "logout@hanyang.ac.kr",
+                "mock-logout-google-access-token",
                 "010-1234-5678",
                 "컴퓨터공학과"
         );


### PR DESCRIPTION
fix(auth): 회원가입 이메일 검증을 Google OAuth 토큰 기반으로 변경

- 회원가입 요청의 email 필드를 accessToken으로 변경
- Google OAuth Access Token으로 사용자 이메일을 서버에서 조회
- 조회된 이메일을 회원가입 Command에 전달하도록 Mapper 수정
- 회원가입 API 설명과 처리 순서 정리
- UserController 테스트 데이터를 Access Token 형식에 맞게 수정