### PR TITLE
chore(local): bootRun이 .env를 자동으로 읽도록 설정 (FOR-112)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,3 +90,40 @@ clean {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/*
+ * 로컬 실행 편의: bootRun에 한해 .env를 환경변수로 주입한다.
+ * `set -a; source .env; set +a` 를 매번 치지 않아도 되게 하는 것이 목적이다.
+ *
+ * bootRun에만 적용하므로 빌드 산출물(java -jar)과 CI 동작은 그대로다.
+ * 서버는 컨테이너가 넘겨주는 환경변수를 쓰며 .env 자체가 없다.
+ */
+tasks.named('bootRun') {
+    def envFile = rootProject.file('.env')
+    if (!envFile.exists()) {
+        return
+    }
+
+    envFile.eachLine { line ->
+        def trimmed = line.trim()
+        if (trimmed.isEmpty() || trimmed.startsWith('#') || !trimmed.contains('=')) {
+            return
+        }
+
+        def separator = trimmed.indexOf('=')
+        def key = trimmed.substring(0, separator).trim()
+        def value = trimmed.substring(separator + 1).trim()
+
+        // KEY="value" / KEY='value' 형태의 감싸는 따옴표만 벗긴다
+        if (value.length() >= 2
+                && ((value.startsWith('"') && value.endsWith('"'))
+                || (value.startsWith("'") && value.endsWith("'")))) {
+            value = value.substring(1, value.length() - 1)
+        }
+
+        // 셸에서 export한 값이 있으면 그쪽을 우선한다 (일회성 오버라이드 허용)
+        if (System.getenv(key) == null) {
+            environment key, value
+        }
+    }
+}


### PR DESCRIPTION
## 배경

로컬에서 백엔드를 띄우려면 매번 이렇게 해야 했습니다.

```bash
set -a; source .env; set +a
SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
```

`application.yml`에 기본 프로파일이 없고, `.env`를 로딩하는 장치(dotenv 플러그인이나 `spring.config.import`)도 없어서 `.env`는 사실상 사람이 읽는 문서일 뿐이었습니다. Spring은 셸 환경변수만 봅니다.

앞부분을 빼먹고 `./gradlew bootRun`만 실행하면 `RDS_PASSWORD`가 빈 값이 되어 기동에 실패하는데, 표면에 드러나는 에러가

```
Unable to determine Dialect without JDBC metadata
```

라서 원인이 비밀번호라는 걸 알아채기 어렵습니다. 실제 원인인 `Access denied for user 'root'`는 스택트레이스 중간에 묻힙니다.

## 변경 사항

`bootRun` 태스크가 실행 직전에 `.env`를 파싱해 환경변수로 주입합니다. `set -a; source .env; set +a`와 같은 효과입니다.

이제 이것만으로 됩니다.

```bash
./gradlew bootRun
```

## 안전장치

- **`bootRun`에만 적용됩니다.** 빌드 산출물(`java -jar`), CI, `test` 태스크는 전혀 영향받지 않습니다. 서버는 컨테이너가 주입하는 환경변수를 쓰고 `.env` 파일 자체가 없습니다.
- **셸 환경변수가 우선입니다.** `System.getenv(key) == null`일 때만 `.env` 값을 넣으므로, `SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun` 처럼 일회성 오버라이드가 가능합니다.
- **`.env`가 없어도 안 깨집니다.** 파일이 없으면 조용히 넘어갑니다. 새로 클론한 환경에서도 문제없습니다.
- `KEY="value"` 형태의 감싸는 따옴표만 벗기고, 주석(`#`)과 빈 줄은 건너뜁니다.

## 확인

환경변수를 모두 비운 셸에서 테스트했습니다.

```bash
env -i HOME="$HOME" PATH="$PATH" ./gradlew bootRun
```

→ 정상 기동, `GET /api/v1/semesters/current` 200 응답 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)