### PR TITLE
feat(admin): 솔라피 템플릿, 입력필드, 발송상태, 필드매핑

### DIFF
--- a/src/main/java/org/forif_backend/application/notification/dto/SendAlimTalkCommand.java
+++ b/src/main/java/org/forif_backend/application/notification/dto/SendAlimTalkCommand.java
@@ -1,14 +1,11 @@
 package org.forif_backend.application.notification.dto;
 
 import java.util.List;
+import java.util.Map;
 
 public record SendAlimTalkCommand(
         List<String> receivers,
         String templateCode,
-        String studyName,
-        String responseSchedule,
-        String dateTime,
-        String location,
-        String url
+        Map<String, String> variables
 ) {
 }

--- a/src/main/java/org/forif_backend/application/notification/dto/SendAlimTalkMessageResult.java
+++ b/src/main/java/org/forif_backend/application/notification/dto/SendAlimTalkMessageResult.java
@@ -1,0 +1,9 @@
+package org.forif_backend.application.notification.dto;
+
+public record SendAlimTalkMessageResult(
+        String receiver,
+        boolean success,
+        String errorCode,
+        String errorMessage
+) {
+}

--- a/src/main/java/org/forif_backend/application/notification/dto/SendAlimTalkResult.java
+++ b/src/main/java/org/forif_backend/application/notification/dto/SendAlimTalkResult.java
@@ -3,6 +3,7 @@ package org.forif_backend.application.notification.dto;
 import java.util.List;
 
 public record SendAlimTalkResult(
-        List<String> results
+        String templateId,
+        List<SendAlimTalkMessageResult> results
 ) {
 }

--- a/src/main/java/org/forif_backend/application/notification/dto/TemplateInfo.java
+++ b/src/main/java/org/forif_backend/application/notification/dto/TemplateInfo.java
@@ -1,5 +1,7 @@
 package org.forif_backend.application.notification.dto;
 
+import java.util.List;
+
 public record TemplateInfo(
         String templateId,
         String name,
@@ -7,6 +9,8 @@ public record TemplateInfo(
         String status,
         String messageType,
         String dateCreated,
-        String dateUpdated
+        String dateUpdated,
+        List<String> variables,
+        List<String> buttonLinks
 ) {
 }

--- a/src/main/java/org/forif_backend/infrastructure/external/notification/NotificationClient.java
+++ b/src/main/java/org/forif_backend/infrastructure/external/notification/NotificationClient.java
@@ -2,6 +2,7 @@ package org.forif_backend.infrastructure.external.notification;
 
 import com.solapi.sdk.SolapiClient;
 import com.solapi.sdk.message.dto.request.kakao.KakaoAlimtalkSendableTemplateListRequest;
+import com.solapi.sdk.message.dto.response.MultipleDetailMessageSentResponse;
 import com.solapi.sdk.message.dto.response.kakao.KakaoAlimtalkTemplateResponse;
 import com.solapi.sdk.message.exception.SolapiMessageNotReceivedException;
 import com.solapi.sdk.message.model.FailedMessage;
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -32,6 +34,11 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 public class NotificationClient implements NotificationSendPort {
+
+    private static final String RECEIVER_CUSTOM_FIELD = "forifReceiver";
+    private static final String UNKNOWN_FAILURE_CODE = "UNKNOWN";
+    private static final String UNMATCHED_FAILURE_MESSAGE = "Solapi 실패 수신자를 식별하지 못했습니다.";
+    private static final String GENERIC_FAILURE_MESSAGE = "Solapi에서 발송을 거절했습니다.";
 
     @Value("${notification.api-key}")
     private String apiKey;
@@ -80,6 +87,7 @@ public class NotificationClient implements NotificationSendPort {
                         Message message = new Message();
                         message.setFrom(senderNumber);
                         message.setTo(phoneNumber);
+                        message.setCustomFields(Map.of(RECEIVER_CUSTOM_FIELD, phoneNumber));
                         message.setKakaoOptions(kakaoOption);
 
                         return message;
@@ -88,37 +96,27 @@ public class NotificationClient implements NotificationSendPort {
 
             try {
                 // 일괄 발송
-                messageService.send(messages);
+                MultipleDetailMessageSentResponse response = messageService.send(messages);
 
-                log.info("Bulk message sent successfully - templateId: {}, receivers: {}",
-                        command.templateCode(), command.receivers().size());
-                List<SendAlimTalkMessageResult> results = command.receivers().stream()
-                        .map(r -> new SendAlimTalkMessageResult(r, true, null, null))
-                        .collect(Collectors.toList());
+                List<SendAlimTalkMessageResult> results = buildSendResults(
+                        command.receivers(),
+                        response.getFailedMessageList(),
+                        false
+                );
+                long failureCount = results.stream().filter(result -> !result.success()).count();
+                log.info("Bulk message send completed - templateId: {}, receivers: {}, failures: {}",
+                        command.templateCode(), command.receivers().size(), failureCount);
 
                 return new SendAlimTalkResult(command.templateCode(), results);
 
             } catch (SolapiMessageNotReceivedException exception) {
                 log.error("Failed to send bulk message - templateId: {}", command.templateCode(), exception);
 
-                Map<String, FailedMessage> failedMessages = exception.getFailedMessageList().stream()
-                        .collect(Collectors.toMap(FailedMessage::getTo, failedMessage -> failedMessage, (first, second) -> first));
-
-                List<SendAlimTalkMessageResult> results = command.receivers().stream()
-                        .map(receiver -> {
-                            FailedMessage failedMessage = failedMessages.get(receiver);
-                            if (failedMessage == null) {
-                                return new SendAlimTalkMessageResult(receiver, true, null, null);
-                            }
-
-                            return new SendAlimTalkMessageResult(
-                                    receiver,
-                                    false,
-                                    failedMessage.getStatusCode(),
-                                    failedMessage.getStatusMessage()
-                            );
-                        })
-                        .collect(Collectors.toList());
+                List<SendAlimTalkMessageResult> results = buildSendResults(
+                        command.receivers(),
+                        exception.getFailedMessageList(),
+                        true
+                );
 
                 return new SendAlimTalkResult(command.templateCode(), results);
 
@@ -136,6 +134,89 @@ public class NotificationClient implements NotificationSendPort {
                 : new HashMap<>(command.variables());
         variables.put("#{이름}", name);  // 수신자별 이름
         return variables;
+    }
+
+    static List<SendAlimTalkMessageResult> buildSendResults(
+            List<String> receivers,
+            List<FailedMessage> failedMessages,
+            boolean allFailed
+    ) {
+        List<FailedMessage> safeFailedMessages = failedMessages == null ? List.of() : failedMessages;
+        Set<String> receiverKeys = receivers.stream()
+                .map(NotificationClient::normalizePhoneNumber)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toSet());
+        Map<String, FailedMessage> failuresByReceiver = new HashMap<>();
+        boolean hasUnmatchedFailure = false;
+
+        for (FailedMessage failedMessage : safeFailedMessages) {
+            if (failedMessage == null) {
+                hasUnmatchedFailure = true;
+                continue;
+            }
+            String receiverKey = normalizePhoneNumber(resolveReceiver(failedMessage));
+            if (receiverKey == null || !receiverKeys.contains(receiverKey)) {
+                hasUnmatchedFailure = true;
+                continue;
+            }
+            failuresByReceiver.putIfAbsent(receiverKey, failedMessage);
+        }
+        boolean hasUnknownReceiverFailure = hasUnmatchedFailure;
+
+        return receivers.stream()
+                .map(receiver -> {
+                    FailedMessage failedMessage = failuresByReceiver.get(normalizePhoneNumber(receiver));
+                    if (failedMessage != null) {
+                        return failureResult(receiver, failedMessage);
+                    }
+                    if (allFailed) {
+                        return unknownFailureResult(receiver, GENERIC_FAILURE_MESSAGE);
+                    }
+                    if (hasUnknownReceiverFailure) {
+                        return unknownFailureResult(receiver, UNMATCHED_FAILURE_MESSAGE);
+                    }
+                    return new SendAlimTalkMessageResult(receiver, true, null, null);
+                })
+                .toList();
+    }
+
+    private static SendAlimTalkMessageResult failureResult(String receiver, FailedMessage failedMessage) {
+        return new SendAlimTalkMessageResult(
+                receiver,
+                false,
+                failedMessage.getStatusCode() == null ? UNKNOWN_FAILURE_CODE : failedMessage.getStatusCode(),
+                failedMessage.getStatusMessage() == null ? GENERIC_FAILURE_MESSAGE : failedMessage.getStatusMessage()
+        );
+    }
+
+    private static SendAlimTalkMessageResult unknownFailureResult(String receiver, String errorMessage) {
+        return new SendAlimTalkMessageResult(receiver, false, UNKNOWN_FAILURE_CODE, errorMessage);
+    }
+
+    private static String resolveReceiver(FailedMessage failedMessage) {
+        Map<String, String> customFields = failedMessage.getCustomFields();
+        if (customFields != null && customFields.get(RECEIVER_CUSTOM_FIELD) != null) {
+            return customFields.get(RECEIVER_CUSTOM_FIELD);
+        }
+        return failedMessage.getTo();
+    }
+
+    private static String normalizePhoneNumber(String phoneNumber) {
+        if (phoneNumber == null) {
+            return null;
+        }
+
+        String digits = phoneNumber.replaceAll("\\D", "");
+        if (digits.isEmpty()) {
+            return null;
+        }
+        if (digits.startsWith("0082")) {
+            return "0" + digits.substring(4);
+        }
+        if (digits.startsWith("82")) {
+            return "0" + digits.substring(2);
+        }
+        return digits;
     }
 
     @Override

--- a/src/main/java/org/forif_backend/infrastructure/external/notification/NotificationClient.java
+++ b/src/main/java/org/forif_backend/infrastructure/external/notification/NotificationClient.java
@@ -4,6 +4,7 @@ import com.solapi.sdk.SolapiClient;
 import com.solapi.sdk.message.dto.request.kakao.KakaoAlimtalkSendableTemplateListRequest;
 import com.solapi.sdk.message.dto.response.kakao.KakaoAlimtalkTemplateResponse;
 import com.solapi.sdk.message.exception.SolapiMessageNotReceivedException;
+import com.solapi.sdk.message.model.FailedMessage;
 import com.solapi.sdk.message.model.Message;
 import com.solapi.sdk.message.model.kakao.KakaoOption;
 import com.solapi.sdk.message.service.DefaultMessageService;
@@ -11,6 +12,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.forif_backend.application.notification.dto.SendAlimTalkCommand;
+import org.forif_backend.application.notification.dto.SendAlimTalkMessageResult;
 import org.forif_backend.application.notification.dto.SendAlimTalkResult;
 import org.forif_backend.application.notification.dto.TemplateInfo;
 import org.forif_backend.application.notification.port.out.NotificationSendPort;
@@ -88,22 +90,37 @@ public class NotificationClient implements NotificationSendPort {
                 // 일괄 발송
                 messageService.send(messages);
 
-                log.info("Bulk message sent successfully to {} receivers", command.receivers().size());
-                List<String> results = command.receivers().stream()
-                        .map(r -> "Success - Receiver: " + r)
+                log.info("Bulk message sent successfully - templateId: {}, receivers: {}",
+                        command.templateCode(), command.receivers().size());
+                List<SendAlimTalkMessageResult> results = command.receivers().stream()
+                        .map(r -> new SendAlimTalkMessageResult(r, true, null, null))
                         .collect(Collectors.toList());
 
-                return new SendAlimTalkResult(results);
+                return new SendAlimTalkResult(command.templateCode(), results);
 
             } catch (SolapiMessageNotReceivedException exception) {
-                log.error("Failed to send bulk message", exception);
+                log.error("Failed to send bulk message - templateId: {}", command.templateCode(), exception);
 
-                // 실패 처리
-                List<String> results = command.receivers().stream()
-                        .map(r -> "Failed - Receiver: " + r)
+                Map<String, FailedMessage> failedMessages = exception.getFailedMessageList().stream()
+                        .collect(Collectors.toMap(FailedMessage::getTo, failedMessage -> failedMessage, (first, second) -> first));
+
+                List<SendAlimTalkMessageResult> results = command.receivers().stream()
+                        .map(receiver -> {
+                            FailedMessage failedMessage = failedMessages.get(receiver);
+                            if (failedMessage == null) {
+                                return new SendAlimTalkMessageResult(receiver, true, null, null);
+                            }
+
+                            return new SendAlimTalkMessageResult(
+                                    receiver,
+                                    false,
+                                    failedMessage.getStatusCode(),
+                                    failedMessage.getStatusMessage()
+                            );
+                        })
                         .collect(Collectors.toList());
 
-                return new SendAlimTalkResult(results);
+                return new SendAlimTalkResult(command.templateCode(), results);
 
             } catch (Exception exception) {
                 log.error("Unexpected error while sending bulk message", exception);
@@ -114,25 +131,10 @@ public class NotificationClient implements NotificationSendPort {
 
     @NotNull
     private static HashMap<String, String> getVariables(SendAlimTalkCommand command, String name) {
-        HashMap<String, String> variables = new HashMap<>();
+        HashMap<String, String> variables = command.variables() == null
+                ? new HashMap<>()
+                : new HashMap<>(command.variables());
         variables.put("#{이름}", name);  // 수신자별 이름
-
-        // 공통 변수 추가
-        if (command.studyName() != null) {
-            variables.put("#{스터디명}", command.studyName());
-        }
-        if (command.responseSchedule() != null) {
-            variables.put("#{응답일정}", command.responseSchedule());
-        }
-        if (command.dateTime() != null) {
-            variables.put("#{일시}", command.dateTime());
-        }
-        if (command.location() != null) {
-            variables.put("#{장소}", command.location());
-        }
-        if (command.url() != null) {
-            variables.put("#{url}", command.url());
-        }
         return variables;
     }
 

--- a/src/main/java/org/forif_backend/infrastructure/external/notification/TemplateMapper.java
+++ b/src/main/java/org/forif_backend/infrastructure/external/notification/TemplateMapper.java
@@ -4,7 +4,9 @@ import com.solapi.sdk.message.dto.response.kakao.KakaoAlimtalkTemplateResponse;
 import org.forif_backend.application.notification.dto.TemplateInfo;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TemplateMapper {
 
@@ -16,7 +18,23 @@ public class TemplateMapper {
                 sdkResponse.getStatus() != null ? sdkResponse.getStatus().toString() : null,
                 sdkResponse.getMessageType() != null ? sdkResponse.getMessageType().toString() : null,
                 sdkResponse.getDateCreated(),
-                sdkResponse.getDateUpdated()
+                sdkResponse.getDateUpdated(),
+                sdkResponse.getVariables() == null
+                        ? List.of()
+                        : sdkResponse.getVariables().stream()
+                                .map(KakaoAlimtalkTemplateResponse.KakaoAlimtalkTemplateVariable::getName)
+                                .toList(),
+                sdkResponse.getButtons() == null
+                        ? List.of()
+                        : sdkResponse.getButtons().stream()
+                                .flatMap(button -> Stream.of(
+                                        button.getLinkMo(),
+                                        button.getLinkPc(),
+                                        button.getLinkAnd(),
+                                        button.getLinkIos()
+                                ))
+                                .filter(Objects::nonNull)
+                                .toList()
         );
     }
 

--- a/src/main/java/org/forif_backend/web/notification/dto/NotificationDtoMapper.java
+++ b/src/main/java/org/forif_backend/web/notification/dto/NotificationDtoMapper.java
@@ -1,6 +1,7 @@
 package org.forif_backend.web.notification.dto;
 
 import org.forif_backend.application.notification.dto.SendAlimTalkCommand;
+import org.forif_backend.application.notification.dto.SendAlimTalkMessageResult;
 import org.forif_backend.application.notification.dto.SendAlimTalkResult;
 
 import java.util.List;
@@ -11,30 +12,34 @@ public class NotificationDtoMapper {
         return new SendAlimTalkCommand(
                 request.receivers(),
                 request.templateCode(),
-                request.studyName(),
-                request.responseSchedule(),
-                request.dateTime(),
-                request.location(),
-                request.url()
+                request.variables()
         );
     }
 
     public static SendAlimTalkResponse toResponse(SendAlimTalkResult result) {
-        List<String> results = result.results();
+        List<SendAlimTalkMessageResult> results = result.results();
 
         long successCount = results.stream()
-                .filter(r -> r.startsWith("Success"))
+                .filter(SendAlimTalkMessageResult::success)
                 .count();
 
         long failureCount = results.stream()
-                .filter(r -> r.startsWith("Failed"))
+                .filter(r -> !r.success())
                 .count();
 
         return new SendAlimTalkResponse(
+                result.templateId(),
                 results.size(),
                 (int) successCount,
                 (int) failureCount,
-                results
+                results.stream()
+                        .map(r -> new SendAlimTalkMessageResponse(
+                                r.receiver(),
+                                r.success(),
+                                r.errorCode(),
+                                r.errorMessage()
+                        ))
+                        .toList()
         );
     }
 }

--- a/src/main/java/org/forif_backend/web/notification/dto/SendAlimTalkMessageResponse.java
+++ b/src/main/java/org/forif_backend/web/notification/dto/SendAlimTalkMessageResponse.java
@@ -1,0 +1,9 @@
+package org.forif_backend.web.notification.dto;
+
+public record SendAlimTalkMessageResponse(
+        String receiver,
+        boolean success,
+        String errorCode,
+        String errorMessage
+) {
+}

--- a/src/main/java/org/forif_backend/web/notification/dto/SendAlimTalkRequest.java
+++ b/src/main/java/org/forif_backend/web/notification/dto/SendAlimTalkRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
+import java.util.Map;
 
 public record SendAlimTalkRequest(
         @NotEmpty(message = "수신자 목록은 비어있을 수 없습니다.")
@@ -14,19 +15,7 @@ public record SendAlimTalkRequest(
         @JsonProperty("templateCode")
         String templateCode,
 
-        @JsonProperty("studyName")
-        String studyName,
-
-        @JsonProperty("responseSchedule")
-        String responseSchedule,
-
-        @JsonProperty("dateTime")
-        String dateTime,
-
-        @JsonProperty("location")
-        String location,
-
-        @JsonProperty("url")
-        String url
+        @JsonProperty("variables")
+        Map<String, String> variables
 ) {
 }

--- a/src/main/java/org/forif_backend/web/notification/dto/SendAlimTalkResponse.java
+++ b/src/main/java/org/forif_backend/web/notification/dto/SendAlimTalkResponse.java
@@ -3,9 +3,10 @@ package org.forif_backend.web.notification.dto;
 import java.util.List;
 
 public record SendAlimTalkResponse(
+        String templateId,
         int totalCount,          // 전체 발송 건수
         int successCount,        // 성공 건수
         int failureCount,        // 실패 건수
-        List<String> results     // 상세 결과
+        List<SendAlimTalkMessageResponse> results     // 상세 결과
 ) {
 }


### PR DESCRIPTION
- 고정 필드 대신 variables 맵으로 템플릿별 변수 전달
- Solapi 템플릿 조회 시 변수·버튼 링크도 응답에 포함
- 발송 결과에 템플릿 ID, 수신자별 성공 여부, Solapi 오류 코드·메시지 추가
- 기존 문자열 결과 배열을 구조화된 결과 객체로 변경