### PR TITLE
feat(study): 멘토 권한을 계정이 아닌 스터디 관계로 판정 (FOR-116)

### DIFF
--- a/src/main/java/org/forif_backend/application/hackathon/HackathonService.java
+++ b/src/main/java/org/forif_backend/application/hackathon/HackathonService.java
@@ -1029,7 +1029,10 @@ public class HackathonService {
     }
 
     private boolean canRegister(HackathonEvent event, Long userId) {
-        return staffAccountRepository.existsByUserId(userId)
+        // 운영진은 ADMIN 계정 보유로 판정한다. 회장이 매 학기 물러난 운영진 계정을
+        // 정리하므로 사실상 현재 학기 운영진과 같다. MENTOR 행까지 세면 역대 멘토가
+        // 전부 영구 자격을 갖게 된다.
+        return staffAccountRepository.existsByUserIdAndRole(userId, StaffRole.ADMIN)
                 || studyUserRepository.existsByUserIdAndStudyYearSemester(
                         userId, event.getHeldYear(), event.getHeldSemester()
                 )

--- a/src/main/java/org/forif_backend/application/study/StudyAttendanceService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyAttendanceService.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 public class StudyAttendanceService {
 
     private final StudyRepository studyRepository;
+    private final StudyMentorAccess studyMentorAccess;
     private final StudyUserRepository studyUserRepository;
     private final StudyAttendanceRepository studyAttendanceRepository;
 
@@ -75,7 +76,7 @@ public class StudyAttendanceService {
      */
     @Transactional
     public void updateAttendance(Long mentorId, Integer studyId, List<AttendanceCommand> commands) {
-        Study study = getStudyIfMentor(mentorId, studyId);
+        Study study = getStudyIfActiveMentor(mentorId, studyId);
 
         Map<Long, StudyUser> menteeMap = studyUserRepository.findAllByStudyId(studyId).stream()
                 .collect(Collectors.toMap(su -> su.getUser().getId(), su -> su));
@@ -113,14 +114,21 @@ public class StudyAttendanceService {
         }
     }
 
+    /** 조회용. 지난 학기 출석부도 본인이 멘토였으면 볼 수 있다. */
     private Study getStudyIfMentor(Long userId, Integer studyId) {
         Study study = studyRepository.findStudyById(studyId)
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
-        if (!study.isMentor(userId)) {
-            throw new ForifException(ErrorCode.NOT_STUDY_MENTOR);
-        }
+        studyMentorAccess.requireMentor(study, userId);
+        return study;
+    }
 
+    /** 변경용. 활동 학기 스터디만 출석을 기록할 수 있다. */
+    private Study getStudyIfActiveMentor(Long userId, Integer studyId) {
+        Study study = studyRepository.findStudyById(studyId)
+                .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
+
+        studyMentorAccess.requireMentorOfActiveSemester(study, userId);
         return study;
     }
 }

--- a/src/main/java/org/forif_backend/application/study/StudyMentorAccess.java
+++ b/src/main/java/org/forif_backend/application/study/StudyMentorAccess.java
@@ -1,0 +1,44 @@
+package org.forif_backend.application.study;
+
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.study.Study;
+import org.springframework.stereotype.Component;
+
+/**
+ * 스터디에 대한 멘토 접근 권한.
+ *
+ * 멘토는 계정 종류가 아니라 "이 스터디의 멘토인가"라는 관계다. 그래서 별도 멘토
+ * 계정 없이 부원 로그인만으로 자기 스터디를 관리할 수 있고, 스터디 멘토를 바꾸면
+ * 다음 요청부터 즉시 반영된다.
+ *
+ * 읽기는 지난 학기 스터디도 허용한다. 자기가 운영했던 스터디의 지원자 명단을
+ * 다시 볼 수 있어야 하기 때문이다. 쓰기는 활동 학기로 제한한다. 학기가 끝난 뒤에
+ * 합불이나 출석이 바뀌면 이미 확정된 결과가 뒤집히기 때문이다.
+ */
+@Component
+@RequiredArgsConstructor
+public class StudyMentorAccess {
+
+    private final SemesterService semesterService;
+
+    /** 조회용. 학기와 무관하게 본인이 멘토인 스터디면 통과한다. */
+    public void requireMentor(Study study, Long userId) {
+        if (!study.isMentor(userId)) {
+            throw new ForifException(ErrorCode.NOT_STUDY_MENTOR);
+        }
+    }
+
+    /** 변경용. 본인이 멘토이면서 활동 학기의 스터디여야 통과한다. */
+    public void requireMentorOfActiveSemester(Study study, Long userId) {
+        requireMentor(study, userId);
+
+        SemesterInfo active = semesterService.getActive();
+        if (study.getActYear() != active.actYear() || study.getActSemester() != active.actSemester()) {
+            throw new ForifException(ErrorCode.STUDY_NOT_IN_ACTIVE_SEMESTER);
+        }
+    }
+}

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -34,7 +34,6 @@ public class StudyService {
 
     // TODO: 하드코딩된 기본 비밀번호 개선 필요. 멘토가 직접 초기 비밀번호를 설정하거나,
     //       랜덤 생성 후 이메일 발송하는 방식으로 변경 필요.
-    private static final String DEFAULT_MENTOR_PASSWORD = "forif1234";
 
     private final SemesterService semesterService;
     private final StudyRepository studyRepository;
@@ -418,28 +417,8 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         study.approve();
-
-        // 멘토 계정 자동 생성
-        createMentorAccountIfAbsent(study.getPrimaryMentor(), study.getStudyName());
-        if (study.getSecondaryMentor() != null) {
-            createMentorAccountIfAbsent(study.getSecondaryMentor(), study.getStudyName());
-        }
-    }
-
-    /**
-     * 멘토 계정이 없으면 기본 비밀번호로 자동 생성
-     */
-    private void createMentorAccountIfAbsent(User mentor, String studyName) {
-        if (staffAccountRepository.existsByUserIdAndRole(mentor.getId(), StaffRole.MENTOR)) {
-            return;
-        }
-
-        CreateMentorCommand command = new CreateMentorCommand(
-                mentor.getId(),
-                DEFAULT_MENTOR_PASSWORD,
-                studyName
-        );
-        staffAccountService.createMentorAccount(command);
+        // 멘토 계정을 따로 만들지 않는다. 멘토 권한은 tb_study의 멘토 관계에서
+        // 요청 시점에 유도되므로, 승인된 순간부터 부원 로그인으로 관리할 수 있다.
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/user/UserApplyService.java
+++ b/src/main/java/org/forif_backend/application/user/UserApplyService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.forif_backend.application.user.dto.ApplyDetailInfo;
 import org.forif_backend.application.user.dto.UserApplyInfo;
 import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.study.StudyMentorAccess;
 import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
@@ -36,6 +37,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class UserApplyService {
     private final SemesterService semesterService;
+    private final StudyMentorAccess studyMentorAccess;
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
     private final StudyUserRepository studyUserRepository;
@@ -115,7 +117,7 @@ public class UserApplyService {
      */
     @Transactional
     public void acceptApplications(Long userId, Integer studyId, List<Long> applyIds) {
-        Study study = getStudyIfMentor(userId, studyId);
+        Study study = getStudyIfActiveMentor(userId, studyId);
 
         for (Long applyId : applyIds) {
             UserApply apply = userRepository.findUserApplyById(applyId);
@@ -162,7 +164,7 @@ public class UserApplyService {
      */
     @Transactional
     public void rejectApplications(Long userId, Integer studyId, List<Long> applyIds) {
-        getStudyIfMentor(userId, studyId);
+        getStudyIfActiveMentor(userId, studyId);
 
         for (Long applyId : applyIds) {
             UserApply apply = userRepository.findUserApplyById(applyId);
@@ -263,7 +265,7 @@ public class UserApplyService {
      */
     @Transactional
     public void updateApplyStatus(Long userId, Integer studyId, Long applyId, UserApplyStatusUpdateRequest request) {
-        Study study = getStudyIfMentor(userId, studyId);
+        Study study = getStudyIfActiveMentor(userId, studyId);
         UserApply userApply = userRepository.findUserApplyById(applyId);
 
         // 신청서가 해당 스터디에 대한 것인지 검증
@@ -279,14 +281,21 @@ public class UserApplyService {
         userApply.updateStatus(study.getId(), request.status());
     }
 
+    /** 조회용. 지난 학기 스터디도 본인이 멘토였으면 볼 수 있다. */
     private Study getStudyIfMentor(Long userId, Integer studyId) {
         Study study = studyRepository.findStudyById(studyId)
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
-        if (!study.isMentor(userId)) {
-            throw new ForifException(ErrorCode.NOT_STUDY_MENTOR);
-        }
+        studyMentorAccess.requireMentor(study, userId);
+        return study;
+    }
 
+    /** 변경용. 활동 학기 스터디만 건드릴 수 있다. */
+    private Study getStudyIfActiveMentor(Long userId, Integer studyId) {
+        Study study = studyRepository.findStudyById(studyId)
+                .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
+
+        studyMentorAccess.requireMentorOfActiveSemester(study, userId);
         return study;
     }
 

--- a/src/main/java/org/forif_backend/application/user/UserService.java
+++ b/src/main/java/org/forif_backend/application/user/UserService.java
@@ -430,6 +430,8 @@ public class UserService {
 
         Map<Long, String> studyNameMap = studyRepository.findCurrentStudyNamesByUserIds(userIds, year, semester);
         Map<Long, StaffRole> staffRoleMap = staffAccountRepository.findStaffRolesByUserIds(userIds);
+        // 멘토는 계정이 아니라 해당 학기 스터디의 멘토 관계로 판정한다
+        Set<Long> mentorUserIds = studyRepository.findMentorUserIdsByUserIds(userIds, year, semester);
 
         return users.stream()
                 .map(u -> MemberResponse.builder()
@@ -438,7 +440,7 @@ public class UserService {
                         .userName(u.getUserName())
                         .phoneNum(u.getPhoneNum())
                         .currentStudyName(studyNameMap.get(u.getId()))
-                        .isMentor(staffRoleMap.get(u.getId()) == StaffRole.MENTOR)
+                        .isMentor(mentorUserIds.contains(u.getId()))
                         .isAdmin(staffRoleMap.get(u.getId()) == StaffRole.ADMIN)
                         .build())
                 .toList();

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     // 403 Forbidden
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "FOR020-403", "권한이 없습니다."),
     NOT_STUDY_MENTOR(HttpStatus.FORBIDDEN, "FOR021-403", "해당 스터디의 멘토가 아닙니다."),
+    STUDY_NOT_IN_ACTIVE_SEMESTER(HttpStatus.FORBIDDEN, "FOR127-403", "지난 학기 스터디는 관리할 수 없습니다."),
     HACKATHON_PARTICIPATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "FOR064-403", "해커톤 참가 자격이 없습니다."),
     HACKATHON_TEAM_LEADER_REQUIRED(HttpStatus.FORBIDDEN, "FOR065-403", "해커톤 팀장 권한이 필요합니다."),
     HACKATHON_EVALUATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "FOR066-403", "해커톤 평가 권한이 없습니다."),

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -95,6 +95,9 @@ public interface StudyRepository {
      */
     boolean existsMentorStudyByMentorIdAndStudyYearSemester(Long mentorId, int year, int semester);
 
+    /** 해당 학기에 멘토로 등록된 유저 ID를 한 번에 추린다 */
+    java.util.Set<Long> findMentorUserIdsByUserIds(java.util.List<Long> userIds, int year, int semester);
+
     /**
      * 스터디 삭제
      */

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
@@ -1,6 +1,8 @@
 package org.forif_backend.infrastructure.persistence.study;
 
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -115,6 +117,32 @@ public class StudyQueryRepository {
         }
 
         return studyTag.name.in(tagNames);
+    }
+
+    /** 해당 학기에 멘토(주·부)로 등록된 유저 ID를 한 번에 추린다 */
+    public Set<Long> findMentorUserIdsByUserIds(List<Long> userIds, int year, int semester) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Set.of();
+        }
+
+        List<Tuple> results = queryFactory
+                .select(study.primaryMentor.id, study.secondaryMentor.id)
+                .from(study)
+                .where(
+                        study.actYear.eq(year),
+                        study.actSemester.eq(semester),
+                        study.primaryMentor.id.in(userIds).or(study.secondaryMentor.id.in(userIds))
+                )
+                .fetch();
+
+        Set<Long> mentorIds = new HashSet<>();
+        for (Tuple t : results) {
+            Long primary = t.get(study.primaryMentor.id);
+            Long secondary = t.get(study.secondaryMentor.id);
+            if (primary != null && userIds.contains(primary)) mentorIds.add(primary);
+            if (secondary != null && userIds.contains(secondary)) mentorIds.add(secondary);
+        }
+        return mentorIds;
     }
 
     public Map<Long, String> findCurrentStudyNamesByUserIds(List<Long> userIds, int year, int semester) {

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -146,6 +146,11 @@ public class StudyRepositoryImpl implements StudyRepository {
     }
 
     @Override
+    public java.util.Set<Long> findMentorUserIdsByUserIds(java.util.List<Long> userIds, int year, int semester) {
+        return studyQueryRepository.findMentorUserIdsByUserIds(userIds, year, semester);
+    }
+
+    @Override
     public void deleteStudyById(Integer studyId) {
         studyJpaRepository.deleteById(studyId);
     }

--- a/src/main/java/org/forif_backend/web/study/StudyController.java
+++ b/src/main/java/org/forif_backend/web/study/StudyController.java
@@ -137,7 +137,6 @@ public class StudyController {
      * @return 멘토가 개설한 스터디 리스트
      */
     @Operation(summary = "내가 개설한 스터디 조회 (멘토 전용)", description = "로그인한 멘토가 개설한 스터디 목록을 조회합니다.")
-    @PreAuthorize("hasRole('MENTOR')")
     @GetMapping("/api/v1/studies/me/created")
     public ResponseEntity<ApiResponse<List<StudyResponse>>> getMyCreatedStudies(@AuthenticationPrincipal Long userId)
     {

--- a/src/main/java/org/forif_backend/web/userApply/UserApplyController.java
+++ b/src/main/java/org/forif_backend/web/userApply/UserApplyController.java
@@ -15,7 +15,6 @@ import org.forif_backend.domain.user.UserApplyStatus;
 import org.forif_backend.web.userApply.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,7 +52,6 @@ public class UserApplyController {
     }
 
     @Operation(summary = "신청자 목록 조회 (멘토 전용)", description = "해당 스터디에 신청한 멘티 목록을 조회합니다. 상태 필터 및 날짜 정렬을 지원합니다.")
-    @PreAuthorize("hasRole('MENTOR')")
     @GetMapping("/{studyId}")
     public ResponseEntity<ApiResponse<PageResponse<UserApplyResponse>>> getUserApply(
                                                                              @AuthenticationPrincipal Long userId,
@@ -69,7 +67,6 @@ public class UserApplyController {
     }
 
     @Operation(summary = "신청서 상세 조회 (멘토 전용)", description = "특정 신청서의 지원 동기 등 상세 내용을 조회합니다.")
-    @PreAuthorize("hasRole('MENTOR')")
     @GetMapping("/{studyId}/{applyId}")
     public ResponseEntity<ApiResponse<UserApplyDetailResponse>> getUserApplyDetail(
                                                                                    @AuthenticationPrincipal Long userId,
@@ -81,7 +78,6 @@ public class UserApplyController {
     }
 
     @Operation(summary = "신청서 상태 변경 (멘토 전용)", description = "신청서의 상태를 PENDING(대기중) 또는 REJECT(탈락)으로 변경합니다. 합격 처리는 /accept 엔드포인트를 사용해주세요.")
-    @PreAuthorize("hasRole('MENTOR')")
     @PatchMapping("/{studyId}/{applyId}/status")
     public ResponseEntity<ApiResponse<Void>> updateApplyStatus(
                                                                 @AuthenticationPrincipal Long userId,
@@ -93,7 +89,6 @@ public class UserApplyController {
     }
 
     @Operation(summary = "합격 처리 (멘토 전용)", description = "신청서 ID 목록을 받아 일괄 합격 처리합니다. 이미 합격인 신청서는 스킵되고, 2순위 합격 상태에서 1순위 합격 시 2순위 StudyUser가 삭제됩니다.")
-    @PreAuthorize("hasRole('MENTOR')")
     @PostMapping("/{studyId}/accept")
     public ResponseEntity<ApiResponse<Void>> acceptApplications(
                                                                  @AuthenticationPrincipal Long userId,
@@ -104,7 +99,6 @@ public class UserApplyController {
     }
 
     @Operation(summary = "불합격 처리 (멘토 전용)", description = "신청서 ID 목록을 받아 일괄 불합격 처리합니다. 이미 불합격인 신청서는 스킵되고, 합격 상태였다면 StudyUser가 삭제됩니다.")
-    @PreAuthorize("hasRole('MENTOR')")
     @PostMapping("/{studyId}/reject")
     public ResponseEntity<ApiResponse<Void>> rejectApplications(
                                                                  @AuthenticationPrincipal Long userId,

--- a/src/test/java/org/forif_backend/application/hackathon/HackathonServiceTest.java
+++ b/src/test/java/org/forif_backend/application/hackathon/HackathonServiceTest.java
@@ -33,10 +33,10 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     HackathonRepository hackathonRepository;
 
     @Test
-    @DisplayName("staff_account 사용자는 해커톤에 참가 등록할 수 있고 중복 등록은 실패한다")
+    @DisplayName("운영진(ADMIN) 계정 사용자는 해커톤에 참가 등록할 수 있고 중복 등록은 실패한다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void registerParticipantByStaffAccount() {
         Long hackathonId = createDefaultHackathon();
@@ -89,7 +89,7 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("팀 생성자는 리더로 자동 등록되고 한 해커톤에서 두 팀에 들어갈 수 없다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void createTeamRegistersLeader() {
         Long hackathonId = createDefaultHackathon();
@@ -115,7 +115,7 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("해커톤 진행 중에도 팀장은 팀 정보를 수정할 수 있다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void updateTeamDuringInProgress() {
         Long hackathonId = createDefaultHackathon();
@@ -145,7 +145,7 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("심사 단계에서는 팀 정보를 수정할 수 없다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void updateTeamDuringJudgingFails() {
         Long hackathonId = createDefaultHackathon();
@@ -241,8 +241,8 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("팀 목록은 해커톤 참가 등록자만 조회할 수 있다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (2, 'pw', '양병현', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (2, 'pw', '양병현', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void teamReadRequiresParticipant() {
         Long hackathonId = createDefaultHackathon();
@@ -259,8 +259,8 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("팀 해산 시 대기 중인 가입 신청을 취소하고 팀원 레코드를 제거한다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (2, 'pw', '양병현', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (2, 'pw', '양병현', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void disbandTeamCancelsPendingJoinRequests() {
         Long hackathonId = createDefaultHackathon();
@@ -283,7 +283,7 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("제출 수정 시 발표자료를 새로 첨부하지 않으면 기존 파일 경로를 유지한다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void updateSubmissionKeepsExistingPresentationFile() {
         when(filePort.uploadFile(any(MultipartFile.class), anyString()))
@@ -333,7 +333,7 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("제출 수정 시 발표자료를 새로 첨부하면 새 파일 경로로 교체한다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void updateSubmissionReplacesPresentationFile() {
         when(filePort.uploadFile(any(MultipartFile.class), anyString()))
@@ -381,7 +381,7 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("허용 목록에 없는 해커톤 기술 태그는 저장할 수 없다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void createSubmissionRejectsInvalidTechStack() {
         Long hackathonId = createDefaultHackathon();
@@ -413,7 +413,7 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("해커톤 기술 스택은 최대 4개까지만 저장할 수 있다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void createSubmissionRejectsTooManyTechStacks() {
         Long hackathonId = createDefaultHackathon();
@@ -445,11 +445,11 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("아카이브 제출작은 주요 수상 결과물 순서로 먼저 조회된다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (2, 'pw', '양병현', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (3, 'pw', '김동현', 'MENTOR', '백엔드', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (4, 'pw', '송준우', 'MENTOR', '기획', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (5, 'pw', '이서준', 'MENTOR', '디자인', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (1, 'pw', '표준성', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (2, 'pw', '양병현', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (3, 'pw', '김동현', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (4, 'pw', '송준우', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (5, 'pw', '이서준', 'ADMIN', '운영진', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     })
     void getArchiveSubmissionsPrioritizesMajorAwards() {
         Long hackathonId = createDefaultHackathon();
@@ -494,8 +494,12 @@ public class HackathonServiceTest extends DefaultMockitoTest {
     @DisplayName("참가자는 본인 팀을 평가할 수 없고 다른 팀은 1~5점 객관식으로 평가한다")
     @Sql({"/sql/user-test-data.sql"})
     @Sql(statements = {
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (2, 'pw', '양병현', 'MENTOR', '웹', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-            "INSERT INTO tb_staff_account (user_id, password, name, role, affiliation, created_at, updated_at) VALUES (3, 'pw', '김동현', 'MENTOR', '백엔드', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            // 운영진이 아니라 해당 학기 수강생으로 참가 자격을 얻는다.
+            // 운영진(ADMIN) 계정이 있으면 평가자 유형이 ADMIN이 되어
+            // 본인 팀 평가 금지 규칙을 검증할 수 없다.
+            "INSERT INTO tb_study (study_id, act_year, act_semester, study_name, primary_mentor_id, primary_mentor_name, study_status, created_at, updated_at) VALUES (2001, 2025, 2, '평가 테스트 스터디', 1, '표준성', 'APPROVED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            "INSERT INTO tb_study_user (study_id, user_id) VALUES (2001, 2)",
+            "INSERT INTO tb_study_user (study_id, user_id) VALUES (2001, 3)"
     })
     void participantEvaluationRules() {
         Long hackathonId = createDefaultHackathon();


### PR DESCRIPTION
## 배경

멘토가 별도 계정(`tb_staff_account` role=MENTOR)과 학번+비밀번호 로그인을 써야 했습니다. 구글 로그인으로 들어오면 본인이 멘토인 스터디가 있어도 관리 기능이 열리지 않아, 같은 사람이 로그인을 두 번 해야 했습니다.

**멘토는 계정 종류가 아니라 "이 스터디의 멘토인가"라는 관계입니다.** `Study.primaryMentor`/`secondaryMentor`가 이미 `User` FK이고 JWT subject도 `User.id`라, 판정 기준만 바꾸면 부원 로그인에서 바로 열립니다.

## 변경 사항

**`@PreAuthorize("hasRole('MENTOR')")` 6곳 제거** — 안쪽에서 이미 `study.isMentor(userId)`로 재검증하고 있어 순수 중복 게이트였습니다. 출석 API 2개는 원래부터 애노테이션 없이 `isMentor`만 검사하고 있어, 권한 모델이 이미 반쪽이었습니다.

**`StudyMentorAccess` 도입 — 읽기·쓰기 분리**

| | 지난 학기 | 활동 학기 |
|---|---|---|
| 조회 (지원자 명단, 출석부) | 허용 | 허용 |
| 변경 (합불, 출석 기록) | **차단** | 허용 |

자기가 운영했던 스터디의 지원자 명단은 계속 볼 수 있어야 하지만, 학기가 끝난 뒤 합불이나 출석이 바뀌면 이미 확정된 결과가 뒤집힙니다.

**부원 목록의 멘토 표시를 학기 멘토 관계로 판정** — 계정 자동 생성을 없애면 `StaffAccount` 기준으로는 신규 멘토가 안 잡힙니다. 배치 조회를 추가해 N+1 없이 처리했습니다.

**해커톤 참가 자격의 운영진 판정을 ADMIN 한정** — 기존 `existsByUserId`는 role을 안 봐서 **역대 멘토가 영구히 자격**을 가졌습니다. 멘티·멘토는 이미 학기 기준이라 그대로 뒀습니다.

**스터디 승인 시 멘토 계정 자동 생성 제거** — 소스에 하드코딩돼 있던 기본 비밀번호(`DEFAULT_MENTOR_PASSWORD`)도 함께 사라집니다.

## MENTOR 행은 지우지 않습니다

알림톡·게시글·해커톤 평가자 판정 등 6곳이 `StaffAccount` 존재에 의존하고, Redis 세션 키가 role별이라 **진행 중인 멘토 세션이 갱신 시 401로 끊깁니다.** 로그인 경로 정리는 프론트 작업과 함께 별도로 진행하는 게 안전합니다.

## 확인

`role=USER` 토큰으로 직접 호출해 검증했습니다.

| 시나리오 | 결과 |
|---|---|
| 내가 개설한 스터디 조회 | 3건 |
| 본인 스터디 신청자 조회 | OK |
| 남의 스터디 접근 | `FOR021-403` |
| 지난 학기 스터디 조회 | OK |
| 지난 학기 합불 처리 | `FOR127-403` |

`./gradlew test` 통과.

**테스트 픽스처 변경** — 해커톤 픽스처의 role을 `ADMIN`으로 옮겼습니다. 참가자 평가 규칙 테스트는 운영진이면 평가자 유형이 `ADMIN`이 되어 본인 팀 평가 금지를 검증할 수 없어, 해당 학기 수강생으로 자격을 얻도록 바꿨습니다.

## 남은 작업 (별도 PR)

- 웹 마이페이지의 `session.role === "MENTOR"` 분기 제거
- 멘토 로그인 탭·`staff-credentials` provider 정리
- 지난 학기 스터디의 관리 버튼 비활성화
- MENTOR 계정 비밀번호 봉인

🤖 Generated with [Claude Code](https://claude.com/claude-code)