### PR TITLE
feat(study): sync recruitment status with mentee schedule

### DIFF
--- a/src/main/java/org/forif_backend/application/study/StudyRecruitStatusScheduler.java
+++ b/src/main/java/org/forif_backend/application/study/StudyRecruitStatusScheduler.java
@@ -1,0 +1,63 @@
+package org.forif_backend.application.study;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.domain.semester.SemesterPhase;
+import org.forif_backend.domain.semester.SemesterSchedule;
+import org.forif_backend.domain.semester.SemesterScheduleRepository;
+import org.forif_backend.domain.study.RecruitStatus;
+import org.forif_backend.domain.study.StudyRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 현재 활동 학기의 멘티 모집 일정에 따라 승인된 스터디의 모집 상태를 자동으로 동기화한다.
+ *
+ * 멘티 모집 기간이 설정된 학기만 대상이며, 기간 안에서는 APPLICABLE,
+ * 기간 전·후에는 CLOSED로 설정한다. 일정이 없는 학기는 기존 fail-open
+ * 정책을 보존하기 위해 변경하지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudyRecruitStatusScheduler {
+
+    private final SemesterService semesterService;
+    private final SemesterScheduleRepository semesterScheduleRepository;
+    private final StudyRepository studyRepository;
+
+    @Scheduled(
+            initialDelayString = "${study.recruit-status-sync.initial-delay-ms:0}",
+            fixedDelayString = "${study.recruit-status-sync.fixed-delay-ms:30000}"
+    )
+    @Transactional
+    public void synchronizeRecruitStatuses() {
+        synchronizeRecruitStatuses(LocalDateTime.now());
+    }
+
+    void synchronizeRecruitStatuses(LocalDateTime now) {
+        SemesterInfo activeSemester = semesterService.getActive();
+        semesterScheduleRepository.findByYearAndSemesterAndPhase(
+                        activeSemester.actYear(), activeSemester.actSemester(), SemesterPhase.MENTEE_RECRUIT)
+                .ifPresent(schedule -> synchronize(schedule, now));
+    }
+
+    private void synchronize(SemesterSchedule schedule, LocalDateTime now) {
+        RecruitStatus targetStatus = schedule.contains(now)
+                ? RecruitStatus.APPLICABLE
+                : RecruitStatus.CLOSED;
+
+        int updatedCount = studyRepository.updateRecruitStatusForApprovedStudies(
+                schedule.getActYear(), schedule.getActSemester(), targetStatus);
+
+        if (updatedCount > 0) {
+            log.info("스터디 모집 상태 동기화: {}년 {}학기 {} → {}건 변경",
+                    schedule.getActYear(), schedule.getActSemester(), targetStatus, updatedCount);
+        }
+    }
+}

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -210,9 +210,6 @@ public class StudyService {
         if (request.getDifficulty() != null) {
             study.setDifficulty(StudyDifficulty.fromLevel(request.getDifficulty()));
         }
-        if (request.getRecruitStatus() != null) {
-            study.setRecruitStatus(RecruitStatus.fromValue(request.getRecruitStatus()));
-        }
 
         // 태그 교체
         if (request.getStudyTagIds() != null) {

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -54,6 +54,9 @@ public interface StudyRepository {
      */
     void saveAllStudyReference(List<StudyReference> references);
 
+    /** 승인된 스터디의 모집 상태를 학기 단위로 일괄 변경한다. */
+    int updateRecruitStatusForApprovedStudies(int actYear, int actSemester, RecruitStatus recruitStatus);
+
     /**
      * 멘토 ID로 스터디 신청 목록 조회
      */

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyJpaRepository.java
@@ -1,7 +1,10 @@
 package org.forif_backend.infrastructure.persistence.study;
 
+import org.forif_backend.domain.study.RecruitStatus;
 import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.study.StudyStatus;
 import org.forif_backend.domain.study.StudyTag;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +19,20 @@ public interface StudyJpaRepository extends JpaRepository<Study, Integer> {
 
     @Query("SELECT DISTINCT s FROM Study s LEFT JOIN FETCH s.tags WHERE s.id IN :studyIds")
     List<Study> findByIdsWithTags(@Param("studyIds") List<Integer> studyIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE Study s
+            SET s.recruitStatus = :recruitStatus,
+                s.updatedAt = CURRENT_TIMESTAMP
+            WHERE s.actYear = :actYear
+              AND s.actSemester = :actSemester
+              AND s.studyStatus = :studyStatus
+              AND (s.recruitStatus IS NULL OR s.recruitStatus <> :recruitStatus)
+            """)
+    int updateRecruitStatusForApprovedStudies(
+            @Param("actYear") int actYear,
+            @Param("actSemester") int actSemester,
+            @Param("recruitStatus") RecruitStatus recruitStatus,
+            @Param("studyStatus") StudyStatus studyStatus);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -97,6 +97,12 @@ public class StudyRepositoryImpl implements StudyRepository {
     }
 
     @Override
+    public int updateRecruitStatusForApprovedStudies(int actYear, int actSemester, RecruitStatus recruitStatus) {
+        return studyJpaRepository.updateRecruitStatusForApprovedStudies(
+                actYear, actSemester, recruitStatus, StudyStatus.APPROVED);
+    }
+
+    @Override
     public List<Study> findAllStudiesByMentorId(Long mentorId) {
         return studyQueryRepository.findAllStudiesByMentorId(mentorId);
     }

--- a/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
@@ -27,7 +27,6 @@ public class UpdateStudyRequest {
     private String locationDetail;
     private Boolean isOnline;
 
-    private String recruitStatus;
     private Integer difficulty;
     private Integer capacity;
     private String selectionCriteria;

--- a/src/test/java/org/forif_backend/application/study/StudyRecruitStatusSchedulerTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyRecruitStatusSchedulerTest.java
@@ -1,0 +1,72 @@
+package org.forif_backend.application.study;
+
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.domain.semester.SemesterPhase;
+import org.forif_backend.domain.semester.SemesterSchedule;
+import org.forif_backend.domain.semester.SemesterScheduleRepository;
+import org.forif_backend.domain.study.RecruitStatus;
+import org.forif_backend.domain.study.StudyRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StudyRecruitStatusSchedulerTest {
+
+    @Mock
+    private SemesterScheduleRepository semesterScheduleRepository;
+
+    @Mock
+    private SemesterService semesterService;
+
+    @Mock
+    private StudyRepository studyRepository;
+
+    @InjectMocks
+    private StudyRecruitStatusScheduler scheduler;
+
+    @Test
+    void opensApprovedStudiesDuringMenteeRecruitment() {
+        LocalDateTime now = LocalDateTime.of(2026, 8, 5, 12, 0);
+        SemesterSchedule schedule = SemesterSchedule.create(
+                2026, 2, SemesterPhase.MENTEE_RECRUIT,
+                now.minusDays(1), now.plusDays(1), 1L);
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
+        when(semesterScheduleRepository.findByYearAndSemesterAndPhase(
+                2026, 2, SemesterPhase.MENTEE_RECRUIT)).thenReturn(Optional.of(schedule));
+
+        scheduler.synchronizeRecruitStatuses(now);
+
+        verify(studyRepository).updateRecruitStatusForApprovedStudies(
+                2026, 2, RecruitStatus.APPLICABLE);
+    }
+
+    @Test
+    void closesApprovedStudiesOutsideMenteeRecruitment() {
+        LocalDateTime now = LocalDateTime.of(2026, 8, 5, 12, 0);
+        SemesterSchedule schedule = SemesterSchedule.create(
+                2026, 2, SemesterPhase.MENTEE_RECRUIT,
+                now.plusDays(1), now.plusDays(8), 1L);
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
+        when(semesterScheduleRepository.findByYearAndSemesterAndPhase(
+                2026, 2, SemesterPhase.MENTEE_RECRUIT)).thenReturn(Optional.of(schedule));
+        when(studyRepository.updateRecruitStatusForApprovedStudies(
+                any(Integer.class), any(Integer.class), any(RecruitStatus.class)))
+                .thenReturn(0);
+
+        scheduler.synchronizeRecruitStatuses(now);
+
+        verify(studyRepository).updateRecruitStatusForApprovedStudies(
+                2026, 2, RecruitStatus.CLOSED);
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 현재 활동 학기의 `MENTEE_RECRUIT` 일정에 따라 승인된 스터디의 모집 상태를 자동 동기화합니다.
  - 기간 내: `APPLICABLE`
  - 기간 전·후: `CLOSED`
- 서버 시작 시 즉시 실행 후 30초마다 상태를 확인합니다.
- 상태가 변경된 스터디만 벌크 업데이트합니다.
- 모집 상태는 일정으로만 관리하도록, 어드민 스터디 수정 API의 수동 `recruitStatus` 변경을 제거했습니다.
- 스케줄러 동작 테스트를 추가했습니다.

## 검증

- `StudyRecruitStatusSchedulerTest` 통과