### PR TITLE
feat(study): 모집 상태가 NULL로 남는 경로 제거

### DIFF
--- a/src/main/java/org/forif_backend/application/study/StudyRecruitStatusPolicy.java
+++ b/src/main/java/org/forif_backend/application/study/StudyRecruitStatusPolicy.java
@@ -1,0 +1,31 @@
+package org.forif_backend.application.study;
+
+import lombok.RequiredArgsConstructor;
+import org.forif_backend.domain.semester.SemesterPhase;
+import org.forif_backend.domain.semester.SemesterScheduleRepository;
+import org.forif_backend.domain.study.RecruitStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * 승인된 스터디가 지금 가져야 할 모집 상태 판정.
+ *
+ * 스케줄러와 스터디 승인이 같은 규칙을 각자 구현하면 어긋나기 때문에 여기로 모았다.
+ *
+ * 멘티 모집 일정이 없는 학기는 APPLICABLE 이다. 신청을 실제로 막는 SemesterPhaseGuard 가
+ * 일정 행이 없으면 통과시키므로(fail-open), 화면만 마감이라고 표시하면 거짓말이 된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class StudyRecruitStatusPolicy {
+
+    private final SemesterScheduleRepository semesterScheduleRepository;
+
+    public RecruitStatus resolve(int actYear, int actSemester, LocalDateTime now) {
+        return semesterScheduleRepository
+                .findByYearAndSemesterAndPhase(actYear, actSemester, SemesterPhase.MENTEE_RECRUIT)
+                .map(schedule -> schedule.contains(now) ? RecruitStatus.APPLICABLE : RecruitStatus.CLOSED)
+                .orElse(RecruitStatus.APPLICABLE);
+    }
+}

--- a/src/main/java/org/forif_backend/application/study/StudyRecruitStatusScheduler.java
+++ b/src/main/java/org/forif_backend/application/study/StudyRecruitStatusScheduler.java
@@ -4,9 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.forif_backend.application.semester.SemesterService;
 import org.forif_backend.application.semester.dto.SemesterInfo;
-import org.forif_backend.domain.semester.SemesterPhase;
-import org.forif_backend.domain.semester.SemesterSchedule;
-import org.forif_backend.domain.semester.SemesterScheduleRepository;
 import org.forif_backend.domain.study.RecruitStatus;
 import org.forif_backend.domain.study.StudyRepository;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,9 +15,9 @@ import java.time.LocalDateTime;
 /**
  * 현재 활동 학기의 멘티 모집 일정에 따라 승인된 스터디의 모집 상태를 자동으로 동기화한다.
  *
- * 멘티 모집 기간이 설정된 학기만 대상이며, 기간 안에서는 APPLICABLE,
- * 기간 전·후에는 CLOSED로 설정한다. 일정이 없는 학기는 기존 fail-open
- * 정책을 보존하기 위해 변경하지 않는다.
+ * 일정이 없는 학기도 대상에 넣는다. 예전에는 건드리지 않고 넘겼는데, 그러면 모집 상태가
+ * NULL로 남아 화면에서 "마감"으로 보였다. 정작 SemesterPhaseGuard는 일정이 없으면
+ * 신청을 통과시키므로 실제로는 신청이 되는 상태였다. 판정은 StudyRecruitStatusPolicy에 맡긴다.
  */
 @Slf4j
 @Component
@@ -28,7 +25,7 @@ import java.time.LocalDateTime;
 public class StudyRecruitStatusScheduler {
 
     private final SemesterService semesterService;
-    private final SemesterScheduleRepository semesterScheduleRepository;
+    private final StudyRecruitStatusPolicy recruitStatusPolicy;
     private final StudyRepository studyRepository;
 
     @Scheduled(
@@ -42,22 +39,15 @@ public class StudyRecruitStatusScheduler {
 
     void synchronizeRecruitStatuses(LocalDateTime now) {
         SemesterInfo activeSemester = semesterService.getActive();
-        semesterScheduleRepository.findByYearAndSemesterAndPhase(
-                        activeSemester.actYear(), activeSemester.actSemester(), SemesterPhase.MENTEE_RECRUIT)
-                .ifPresent(schedule -> synchronize(schedule, now));
-    }
-
-    private void synchronize(SemesterSchedule schedule, LocalDateTime now) {
-        RecruitStatus targetStatus = schedule.contains(now)
-                ? RecruitStatus.APPLICABLE
-                : RecruitStatus.CLOSED;
+        RecruitStatus targetStatus =
+                recruitStatusPolicy.resolve(activeSemester.actYear(), activeSemester.actSemester(), now);
 
         int updatedCount = studyRepository.updateRecruitStatusForApprovedStudies(
-                schedule.getActYear(), schedule.getActSemester(), targetStatus);
+                activeSemester.actYear(), activeSemester.actSemester(), targetStatus);
 
         if (updatedCount > 0) {
             log.info("스터디 모집 상태 동기화: {}년 {}학기 {} → {}건 변경",
-                    schedule.getActYear(), schedule.getActSemester(), targetStatus, updatedCount);
+                    activeSemester.actYear(), activeSemester.actSemester(), targetStatus, updatedCount);
         }
     }
 }

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -39,6 +40,7 @@ public class StudyService {
 
     private final SemesterService semesterService;
     private final SemesterPhaseGuard semesterPhaseGuard;
+    private final StudyRecruitStatusPolicy recruitStatusPolicy;
     private final StudyRepository studyRepository;
     private final StudyUserRepository studyUserRepository;
     private final UserRepository userRepository;
@@ -411,7 +413,6 @@ public class StudyService {
 
     /**
      * [어드민 전용] 스터디 개설 승인
-     * 승인 시 멘토(primary, secondary) 계정이 없으면 자동 생성
      */
     @Transactional
     public void approveStudy(Integer studyId) {
@@ -421,6 +422,10 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         study.approve();
+        // 스케줄러가 30초마다 맞춰주지만 그 사이 모집 상태가 NULL로 남아 화면에서 "마감"으로
+        // 보인다. 승인하자마자 옳은 값이 보이도록 여기서 먼저 채운다.
+        study.setRecruitStatus(recruitStatusPolicy.resolve(
+                study.getActYear(), study.getActSemester(), LocalDateTime.now()));
         // 멘토 계정을 따로 만들지 않는다. 멘토 권한은 tb_study의 멘토 관계에서
         // 요청 시점에 유도되므로, 승인된 순간부터 부원 로그인으로 관리할 수 있다.
     }

--- a/src/test/java/org/forif_backend/application/study/StudyRecruitStatusPolicyTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyRecruitStatusPolicyTest.java
@@ -1,0 +1,72 @@
+package org.forif_backend.application.study;
+
+import org.forif_backend.domain.semester.SemesterPhase;
+import org.forif_backend.domain.semester.SemesterSchedule;
+import org.forif_backend.domain.semester.SemesterScheduleRepository;
+import org.forif_backend.domain.study.RecruitStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StudyRecruitStatusPolicyTest {
+
+    @Mock
+    private SemesterScheduleRepository semesterScheduleRepository;
+
+    @InjectMocks
+    private StudyRecruitStatusPolicy policy;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 5, 12, 0);
+
+    private void givenSchedule(LocalDateTime startsAt, LocalDateTime endsAt) {
+        when(semesterScheduleRepository.findByYearAndSemesterAndPhase(2026, 2, SemesterPhase.MENTEE_RECRUIT))
+                .thenReturn(Optional.of(SemesterSchedule.create(
+                        2026, 2, SemesterPhase.MENTEE_RECRUIT, startsAt, endsAt, 1L)));
+    }
+
+    @Test
+    void 모집_기간_안이면_APPLICABLE() {
+        givenSchedule(NOW.minusDays(1), NOW.plusDays(1));
+
+        assertThat(policy.resolve(2026, 2, NOW)).isEqualTo(RecruitStatus.APPLICABLE);
+    }
+
+    @Test
+    void 모집_시작_전이면_CLOSED() {
+        givenSchedule(NOW.plusDays(1), NOW.plusDays(8));
+
+        assertThat(policy.resolve(2026, 2, NOW)).isEqualTo(RecruitStatus.CLOSED);
+    }
+
+    @Test
+    void 모집_종료_후면_CLOSED() {
+        givenSchedule(NOW.minusDays(8), NOW.minusDays(1));
+
+        assertThat(policy.resolve(2026, 2, NOW)).isEqualTo(RecruitStatus.CLOSED);
+    }
+
+    @Test
+    void 종료_시각_당일은_반열림_구간이라_CLOSED() {
+        givenSchedule(NOW.minusDays(1), NOW);
+
+        assertThat(policy.resolve(2026, 2, NOW)).isEqualTo(RecruitStatus.CLOSED);
+    }
+
+    /** SemesterPhaseGuard가 일정 없는 학기의 신청을 통과시키므로 화면도 열려 있어야 한다 */
+    @Test
+    void 일정이_없으면_APPLICABLE() {
+        when(semesterScheduleRepository.findByYearAndSemesterAndPhase(2026, 2, SemesterPhase.MENTEE_RECRUIT))
+                .thenReturn(Optional.empty());
+
+        assertThat(policy.resolve(2026, 2, NOW)).isEqualTo(RecruitStatus.APPLICABLE);
+    }
+}

--- a/src/test/java/org/forif_backend/application/study/StudyRecruitStatusSchedulerTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyRecruitStatusSchedulerTest.java
@@ -2,9 +2,6 @@ package org.forif_backend.application.study;
 
 import org.forif_backend.application.semester.SemesterService;
 import org.forif_backend.application.semester.dto.SemesterInfo;
-import org.forif_backend.domain.semester.SemesterPhase;
-import org.forif_backend.domain.semester.SemesterSchedule;
-import org.forif_backend.domain.semester.SemesterScheduleRepository;
 import org.forif_backend.domain.study.RecruitStatus;
 import org.forif_backend.domain.study.StudyRepository;
 import org.junit.jupiter.api.Test;
@@ -14,9 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,10 +19,10 @@ import static org.mockito.Mockito.when;
 class StudyRecruitStatusSchedulerTest {
 
     @Mock
-    private SemesterScheduleRepository semesterScheduleRepository;
+    private SemesterService semesterService;
 
     @Mock
-    private SemesterService semesterService;
+    private StudyRecruitStatusPolicy recruitStatusPolicy;
 
     @Mock
     private StudyRepository studyRepository;
@@ -35,38 +30,40 @@ class StudyRecruitStatusSchedulerTest {
     @InjectMocks
     private StudyRecruitStatusScheduler scheduler;
 
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 5, 12, 0);
+
     @Test
-    void opensApprovedStudiesDuringMenteeRecruitment() {
-        LocalDateTime now = LocalDateTime.of(2026, 8, 5, 12, 0);
-        SemesterSchedule schedule = SemesterSchedule.create(
-                2026, 2, SemesterPhase.MENTEE_RECRUIT,
-                now.minusDays(1), now.plusDays(1), 1L);
+    void 모집_기간_안이면_활동_학기_스터디를_APPLICABLE로_동기화한다() {
         when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
-        when(semesterScheduleRepository.findByYearAndSemesterAndPhase(
-                2026, 2, SemesterPhase.MENTEE_RECRUIT)).thenReturn(Optional.of(schedule));
+        when(recruitStatusPolicy.resolve(2026, 2, NOW)).thenReturn(RecruitStatus.APPLICABLE);
 
-        scheduler.synchronizeRecruitStatuses(now);
+        scheduler.synchronizeRecruitStatuses(NOW);
 
-        verify(studyRepository).updateRecruitStatusForApprovedStudies(
-                2026, 2, RecruitStatus.APPLICABLE);
+        verify(studyRepository).updateRecruitStatusForApprovedStudies(2026, 2, RecruitStatus.APPLICABLE);
     }
 
     @Test
-    void closesApprovedStudiesOutsideMenteeRecruitment() {
-        LocalDateTime now = LocalDateTime.of(2026, 8, 5, 12, 0);
-        SemesterSchedule schedule = SemesterSchedule.create(
-                2026, 2, SemesterPhase.MENTEE_RECRUIT,
-                now.plusDays(1), now.plusDays(8), 1L);
+    void 모집_기간_밖이면_CLOSED로_동기화한다() {
         when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
-        when(semesterScheduleRepository.findByYearAndSemesterAndPhase(
-                2026, 2, SemesterPhase.MENTEE_RECRUIT)).thenReturn(Optional.of(schedule));
-        when(studyRepository.updateRecruitStatusForApprovedStudies(
-                any(Integer.class), any(Integer.class), any(RecruitStatus.class)))
-                .thenReturn(0);
+        when(recruitStatusPolicy.resolve(2026, 2, NOW)).thenReturn(RecruitStatus.CLOSED);
 
-        scheduler.synchronizeRecruitStatuses(now);
+        scheduler.synchronizeRecruitStatuses(NOW);
 
-        verify(studyRepository).updateRecruitStatusForApprovedStudies(
-                2026, 2, RecruitStatus.CLOSED);
+        verify(studyRepository).updateRecruitStatusForApprovedStudies(2026, 2, RecruitStatus.CLOSED);
+    }
+
+    /**
+     * 예전에는 일정이 없는 학기를 건너뛰어 모집 상태가 NULL로 남았고,
+     * 프론트가 NULL을 "마감"으로 그려서 실제 신청 가능 여부와 어긋났다.
+     * 이제는 정책이 돌려주는 값으로 반드시 동기화한다.
+     */
+    @Test
+    void 일정이_없는_학기도_건너뛰지_않는다() {
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
+        when(recruitStatusPolicy.resolve(2026, 2, NOW)).thenReturn(RecruitStatus.APPLICABLE);
+
+        scheduler.synchronizeRecruitStatuses(NOW);
+
+        verify(studyRepository).updateRecruitStatusForApprovedStudies(2026, 2, RecruitStatus.APPLICABLE);
     }
 }


### PR DESCRIPTION
## 문제

승인된 스터디의 `recruit_status`가 NULL로 남는 경로가 두 개 있습니다. 프론트는 전부 `=== "APPLICABLE" ? "모집중" : "마감"`으로 렌더링하기 때문에 **NULL은 화면·엑셀에서 모두 "마감"으로 보입니다.**

정작 신청을 실제로 막는 `SemesterPhaseGuard`는 일정 행이 없으면 통과시키므로(fail-open), 신청은 정상적으로 됩니다. 화면만 거짓말을 하는 상태였습니다.

| 경로 | 원인 |
|---|---|
| 일정 미설정 학기 | 스케줄러가 `.ifPresent`라 건너뛰어 NULL이 영구히 남음 |
| 승인 직후 | `approveStudy()`가 `recruit_status`를 설정하지 않아 다음 tick(최대 30초)까지 NULL |

## 변경

**`StudyRecruitStatusPolicy`** (신규) — 판정 규칙을 한 곳에 모았습니다. 스케줄러와 승인이 같은 규칙을 각자 구현하면 어긋나기 때문입니다.

- 멘티 모집 기간 안 → `APPLICABLE`
- 기간 전·후 → `CLOSED`
- **일정 없음 → `APPLICABLE`** (가드의 fail-open 정책과 일치)

**`StudyRecruitStatusScheduler`** — 일정 없는 학기도 건너뛰지 않고 동기화합니다.

**`StudyService.approveStudy()`** — 승인 시점에 값을 채워 NULL 구간을 없앱니다.

## 검증

로컬 `forif_dev`에서 실제로 확인했습니다.

- 일정이 **하나도 없는** 26-2 학기 + `recruit_status = NULL` 승인 스터디 → 부팅 즉시 `APPLICABLE`로 전환 (`2026년 2학기 APPLICABLE → 1건 변경`)
- `compileJava`, `test` 통과
- `StudyRecruitStatusPolicyTest` 5케이스 추가 (기간 안/전/후, 반열림 경계, 일정 없음)
- `StudyRecruitStatusSchedulerTest`를 새 구조에 맞게 갱신

## 참고

기존 DB 행에 대한 마이그레이션은 필요 없습니다. 현재 `tb_study`의 `recruit_status`는 전부 `CLOSED`이고, 활동 학기 행은 스케줄러가 다음 tick에 맞춥니다.