### PR TITLE
(admin): 회비 관리 및 문자발송 대상 조회 기능 개편

### DIFF
--- a/src/main/java/org/forif_backend/application/dues/DuesService.java
+++ b/src/main/java/org/forif_backend/application/dues/DuesService.java
@@ -10,15 +10,21 @@ import org.forif_backend.domain.dues.MemberSemesterCheck;
 import org.forif_backend.domain.dues.MemberSemesterCheckRepository;
 import org.forif_backend.domain.study.Study;
 import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.StudyUser;
 import org.forif_backend.domain.study.StudyUserRepository;
 import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserApply;
+import org.forif_backend.domain.user.UserApplyRepository;
+import org.forif_backend.domain.user.UserApplyStatus;
 import org.forif_backend.domain.user.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -33,6 +39,7 @@ public class DuesService {
     private final StudyUserRepository studyUserRepository;
     private final StudyRepository studyRepository;
     private final UserRepository userRepository;
+    private final UserApplyRepository userApplyRepository;
     private final MemberSemesterCheckRepository memberSemesterCheckRepository;
 
     public DuesPageResult getCurrentSemesterDues(
@@ -42,7 +49,7 @@ public class DuesService {
             DuesSort sort
     ) {
         SemesterInfo semester = semesterService.getActive();
-        List<User> users = studyUserRepository.findUsersByYearSemester(
+        List<User> users = findDuesTargets(
                 semester.actYear(),
                 semester.actSemester(),
                 search
@@ -83,11 +90,11 @@ public class DuesService {
             SemesterInfo semester
     ) {
         Long userId = command.userId();
-        if (!studyUserRepository.existsByUserIdAndStudyYearSemester(
-                userId,
-                semester.actYear(),
-                semester.actSemester()
-        )) {
+        boolean isMember = studyUserRepository.existsByUserIdAndStudyYearSemester(
+                userId, semester.actYear(), semester.actSemester());
+        boolean isApplicant = userApplyRepository.existsByApplierIdAndYearSemester(
+                userId, semester.actYear(), semester.actSemester());
+        if (!isMember && !isApplicant) {
             throw new ForifException(ErrorCode.USER_NOT_FOUND);
         }
 
@@ -99,6 +106,7 @@ public class DuesService {
                 .orElseGet(() -> MemberSemesterCheck.create(user, semester.actYear(), semester.actSemester()));
         memberCheck.update(command.duesPaid(), command.googleFormSubmitted());
         memberSemesterCheckRepository.save(memberCheck);
+        synchronizeStudyMembership(user, semester, memberCheck);
     }
 
     @Transactional
@@ -108,6 +116,65 @@ public class DuesService {
                 .orElseGet(() -> memberSemesterCheckRepository.save(
                         MemberSemesterCheck.create(user, study.getActYear(), study.getActSemester())
                 ));
+    }
+
+    /**
+     * 스터디 합격자 중 회비 납부와 구글폼 제출을 모두 확인한 경우에만 수강생으로 등록한다.
+     */
+    @Transactional
+    public void registerStudyUserIfEligible(Study study, User user) {
+        memberSemesterCheckRepository
+                .findByUserIdAndYearSemester(user.getId(), study.getActYear(), study.getActSemester())
+                .ifPresent(memberCheck -> registerStudyUserIfEligible(study, user, memberCheck));
+    }
+
+    private void registerStudyUserIfEligible(Study study, User user, MemberSemesterCheck memberCheck) {
+        if (!memberCheck.isDuesPaid() || !memberCheck.isGoogleFormSubmitted()) {
+            return;
+        }
+        studyUserRepository.findByUserIdAndStudyId(user.getId(), study.getId())
+                .orElseGet(() -> {
+                    StudyUser studyUser = StudyUser.create(study, user);
+                    studyUserRepository.save(studyUser);
+                    return studyUser;
+                });
+    }
+
+    private void synchronizeStudyMembership(
+            User user,
+            SemesterInfo semester,
+            MemberSemesterCheck memberCheck
+    ) {
+        userRepository.findUserApplyByYearAndSemesterAndUser(
+                        semester.actYear(), semester.actSemester(), user)
+                .flatMap(this::acceptedStudyId)
+                .flatMap(studyRepository::findStudyById)
+                .ifPresent(study -> {
+                    if (memberCheck.isDuesPaid() && memberCheck.isGoogleFormSubmitted()) {
+                        registerStudyUserIfEligible(study, user, memberCheck);
+                    } else {
+                        studyUserRepository.deleteByUserIdAndStudyId(user.getId(), study.getId());
+                    }
+                });
+    }
+
+    private Optional<Integer> acceptedStudyId(UserApply apply) {
+        if (apply.getPrimaryStatus() == UserApplyStatus.ACCEPT) {
+            return Optional.of(apply.getPrimaryStudy());
+        }
+        if (apply.getSecondaryStatus() == UserApplyStatus.ACCEPT) {
+            return Optional.ofNullable(apply.getSecondaryStudy());
+        }
+        return Optional.empty();
+    }
+
+    private List<User> findDuesTargets(int year, int semester, String search) {
+        Map<Long, User> usersById = new LinkedHashMap<>();
+        studyUserRepository.findUsersByYearSemester(year, semester, search)
+                .forEach(user -> usersById.put(user.getId(), user));
+        userApplyRepository.findApplicantsByYearSemester(year, semester, search)
+                .forEach(user -> usersById.putIfAbsent(user.getId(), user));
+        return List.copyOf(usersById.values());
     }
 
     private List<DuesMember> toDuesMembers(List<User> users, SemesterInfo semester) {

--- a/src/main/java/org/forif_backend/application/notification/NotificationService.java
+++ b/src/main/java/org/forif_backend/application/notification/NotificationService.java
@@ -5,12 +5,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.forif_backend.application.notification.dto.SendAlimTalkCommand;
 import org.forif_backend.application.notification.dto.SendAlimTalkResult;
 import org.forif_backend.application.notification.dto.TemplateInfo;
+import org.forif_backend.application.notification.dto.NotificationRecipientTarget;
 import org.forif_backend.application.notification.port.out.NotificationSendPort;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.application.user.UserService;
+import org.forif_backend.common.dto.response.CursorPageResponse;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.domain.staff.StaffAccountRepository;
 import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.UserRepository;
+import org.forif_backend.web.user.dto.MemberResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,9 +31,13 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class NotificationService {
 
+    private static final int MAX_RECIPIENT_PAGE_SIZE = 100;
+
     private final NotificationSendPort notificationSendPort;
     private final StaffAccountRepository staffAccountRepository;
     private final UserRepository userRepository;
+    private final SemesterService semesterService;
+    private final UserService userService;
 
     public CompletableFuture<SendAlimTalkResult> sendAlimTalk(
             SendAlimTalkCommand command,
@@ -56,5 +66,38 @@ public class NotificationService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STAFF_NOT_FOUND));
 
         return notificationSendPort.getKakaoTemplates();
+    }
+
+    public CursorPageResponse<MemberResponse> getRecipients(
+            NotificationRecipientTarget target,
+            Long cursor,
+            int size,
+            String search
+    ) {
+        int safeSize = Math.max(1, Math.min(size, MAX_RECIPIENT_PAGE_SIZE));
+        SemesterInfo currentSemester = semesterService.getActive();
+
+        return switch (target) {
+            case CURRENT_SEMESTER_MEMBERS -> userService.getNotificationMembers(
+                    currentSemester.actYear(), currentSemester.actSemester(), cursor, safeSize, search);
+            case CURRENT_SEMESTER_APPLICANTS -> userService.getApplicants(
+                    currentSemester.actYear(), currentSemester.actSemester(), cursor, safeSize, search);
+            case PREVIOUS_SEMESTER_MEMBERS -> {
+                SemesterInfo previousSemester = previousOf(currentSemester);
+                yield userService.getNotificationMembers(
+                        previousSemester.actYear(), previousSemester.actSemester(), cursor, safeSize, search);
+            }
+            case ALL_MEMBERS -> userService.getNotificationMembers(cursor, safeSize, search);
+            case ACCEPTED_DUES_UNPAID -> userService.getAcceptedUsersMissingDues(
+                    currentSemester.actYear(), currentSemester.actSemester(), cursor, safeSize, search);
+            case ACCEPTED_GOOGLE_FORM_NOT_SUBMITTED -> userService.getAcceptedUsersMissingGoogleForm(
+                    currentSemester.actYear(), currentSemester.actSemester(), cursor, safeSize, search);
+        };
+    }
+
+    private SemesterInfo previousOf(SemesterInfo semester) {
+        return semester.actSemester() == 1
+                ? SemesterInfo.of(semester.actYear() - 1, 2)
+                : SemesterInfo.of(semester.actYear(), 1);
     }
 }

--- a/src/main/java/org/forif_backend/application/notification/dto/NotificationRecipientTarget.java
+++ b/src/main/java/org/forif_backend/application/notification/dto/NotificationRecipientTarget.java
@@ -1,0 +1,10 @@
+package org.forif_backend.application.notification.dto;
+
+public enum NotificationRecipientTarget {
+    CURRENT_SEMESTER_MEMBERS,
+    CURRENT_SEMESTER_APPLICANTS,
+    PREVIOUS_SEMESTER_MEMBERS,
+    ALL_MEMBERS,
+    ACCEPTED_DUES_UNPAID,
+    ACCEPTED_GOOGLE_FORM_NOT_SUBMITTED
+}

--- a/src/main/java/org/forif_backend/application/user/UserApplyService.java
+++ b/src/main/java/org/forif_backend/application/user/UserApplyService.java
@@ -15,7 +15,6 @@ import org.forif_backend.common.type.SortDirection;
 import org.forif_backend.common.util.DateUtils;
 import org.forif_backend.domain.study.Study;
 import org.forif_backend.domain.study.StudyRepository;
-import org.forif_backend.domain.study.StudyUser;
 import org.forif_backend.domain.study.StudyUserRepository;
 import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.UserApply;
@@ -161,10 +160,8 @@ public class UserApplyService {
             }
 
             apply.updateStatus(studyId, UserApplyStatus.ACCEPT);
-
-            StudyUser studyUser = StudyUser.create(study, apply.getApplier());
-            studyUserRepository.save(studyUser);
             duesService.ensureMemberCheck(study, apply.getApplier());
+            duesService.registerStudyUserIfEligible(study, apply.getApplier());
         }
     }
 

--- a/src/main/java/org/forif_backend/application/user/UserService.java
+++ b/src/main/java/org/forif_backend/application/user/UserService.java
@@ -425,6 +425,71 @@ public class UserService {
         return CursorPageResponse.ofCursor(responses, nextCursor != null ? nextCursor.intValue() : null, hasNext, totalElements);
     }
 
+    /** 현재 학기 스터디 합격 여부와 관계없이 해당 학기에 스터디를 신청한 사용자 목록 조회 */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<MemberResponse> getApplicants(int year, int semester, Long cursor, int size, String search) {
+        long totalElements = userRepository.countApplicantsByYearSemester(year, semester, search);
+        List<User> users = userRepository.searchApplicantsByYearSemester(year, semester, cursor, size, search);
+        boolean hasNext = users.size() > size;
+        List<User> content = hasNext ? users.subList(0, size) : users;
+        List<MemberResponse> responses = buildMemberResponses(content, year, semester);
+        Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
+        return CursorPageResponse.ofCursor(responses, nextCursor != null ? nextCursor.intValue() : null, hasNext, totalElements);
+    }
+
+    /** 문자 발송 수신자용 전체 부원 조회. 검색은 이름 또는 학번으로만 수행한다. */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<MemberResponse> getNotificationMembers(Long cursor, int size, String search) {
+        SemesterInfo active = semesterService.getActive();
+        long totalElements = userRepository.countNotificationUsers(search);
+        List<User> users = userRepository.searchNotificationUsersWithCursor(cursor, size, search);
+        return toCursorMemberPage(users, totalElements, size, active.actYear(), active.actSemester());
+    }
+
+    /** 문자 발송 수신자용 학기 부원 조회. 검색은 이름 또는 학번으로만 수행한다. */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<MemberResponse> getNotificationMembers(
+            int year, int semester, Long cursor, int size, String search
+    ) {
+        long totalElements = userRepository.countNotificationUsersByYearSemester(year, semester, search);
+        List<User> users = userRepository.searchNotificationUsersByYearSemester(year, semester, cursor, size, search);
+        return toCursorMemberPage(users, totalElements, size, year, semester);
+    }
+
+    /** 회비 미납 상태인 현재 학기 합격자 조회. */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<MemberResponse> getAcceptedUsersMissingDues(
+            int year, int semester, Long cursor, int size, String search
+    ) {
+        long totalElements = userRepository.countAcceptedUsersMissingDuesByYearSemester(year, semester, search);
+        List<User> users = userRepository.searchAcceptedUsersMissingDuesByYearSemester(year, semester, cursor, size, search);
+        return toCursorMemberPage(users, totalElements, size, year, semester);
+    }
+
+    /** 구글폼을 미제출한 현재 학기 합격자 조회. */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<MemberResponse> getAcceptedUsersMissingGoogleForm(
+            int year, int semester, Long cursor, int size, String search
+    ) {
+        long totalElements = userRepository.countAcceptedUsersMissingGoogleFormByYearSemester(year, semester, search);
+        List<User> users = userRepository.searchAcceptedUsersMissingGoogleFormByYearSemester(year, semester, cursor, size, search);
+        return toCursorMemberPage(users, totalElements, size, year, semester);
+    }
+
+    private CursorPageResponse<MemberResponse> toCursorMemberPage(
+            List<User> users,
+            long totalElements,
+            int size,
+            int year,
+            int semester
+    ) {
+        boolean hasNext = users.size() > size;
+        List<User> content = hasNext ? users.subList(0, size) : users;
+        List<MemberResponse> responses = buildMemberResponses(content, year, semester);
+        Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
+        return CursorPageResponse.ofCursor(responses, nextCursor != null ? nextCursor.intValue() : null, hasNext, totalElements);
+    }
+
     private List<MemberResponse> buildMemberResponses(List<User> users, int year, int semester) {
         List<Long> userIds = users.stream().map(User::getId).toList();
 

--- a/src/main/java/org/forif_backend/domain/user/UserApplyRepository.java
+++ b/src/main/java/org/forif_backend/domain/user/UserApplyRepository.java
@@ -2,6 +2,8 @@ package org.forif_backend.domain.user;
 
 import java.util.List;
 
+import org.forif_backend.domain.user.User;
+
 public interface UserApplyRepository {
     /**
      * 사용자 ID로 스터디 신청 목록 조회
@@ -9,4 +11,8 @@ public interface UserApplyRepository {
      * @return 스터디 신청 목록 (최신 학기순 정렬: 연도 DESC, 학기 DESC)
      */
     List<UserApply> findAllUserApplyByUserId(Long userId);
+
+    List<User> findApplicantsByYearSemester(int year, int semester, String search);
+
+    boolean existsByApplierIdAndYearSemester(Long userId, int year, int semester);
 }

--- a/src/main/java/org/forif_backend/domain/user/UserRepository.java
+++ b/src/main/java/org/forif_backend/domain/user/UserRepository.java
@@ -44,4 +44,24 @@ public interface UserRepository {
     List<User> searchUsersByYearSemesterWithOffset(int year, int semester, int page, int size, String search);
 
     long countUsersByYearSemester(int year, int semester, String search);
+
+    List<User> searchNotificationUsersWithCursor(Long cursor, int size, String search);
+
+    long countNotificationUsers(String search);
+
+    List<User> searchNotificationUsersByYearSemester(int year, int semester, Long cursor, int size, String search);
+
+    long countNotificationUsersByYearSemester(int year, int semester, String search);
+
+    List<User> searchApplicantsByYearSemester(int year, int semester, Long cursor, int size, String search);
+
+    long countApplicantsByYearSemester(int year, int semester, String search);
+
+    List<User> searchAcceptedUsersMissingDuesByYearSemester(int year, int semester, Long cursor, int size, String search);
+
+    long countAcceptedUsersMissingDuesByYearSemester(int year, int semester, String search);
+
+    List<User> searchAcceptedUsersMissingGoogleFormByYearSemester(int year, int semester, Long cursor, int size, String search);
+
+    long countAcceptedUsersMissingGoogleFormByYearSemester(int year, int semester, String search);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/user/UserApplyJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/user/UserApplyJpaRepository.java
@@ -14,4 +14,21 @@ public interface UserApplyJpaRepository extends JpaRepository<UserApply, Long> {
     UserApply findByid(Long id);
 
     List<UserApply> findByApplierId(Long applierId);
+
+    @Query("""
+            SELECT DISTINCT ua.applier FROM UserApply ua
+            WHERE ua.applyYear = :year
+              AND ua.applySemester = :semester
+              AND (
+                  :search IS NULL OR :search = ''
+                  OR LOWER(ua.applier.userName) LIKE LOWER(CONCAT('%', :search, '%'))
+                  OR LOWER(ua.applier.department) LIKE LOWER(CONCAT('%', :search, '%'))
+              )
+            ORDER BY ua.applier.userName ASC, ua.applier.id ASC
+            """)
+    List<User> findApplicantsByYearSemester(@Param("year") int year,
+                                            @Param("semester") int semester,
+                                            @Param("search") String search);
+
+    boolean existsByApplierIdAndApplyYearAndApplySemester(Long applierId, int applyYear, int applySemester);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/user/UserApplyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/user/UserApplyRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.forif_backend.infrastructure.persistence.user;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.domain.user.UserApply;
 import org.forif_backend.domain.user.UserApplyRepository;
+import org.forif_backend.domain.user.User;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,5 +16,15 @@ public class UserApplyRepositoryImpl implements UserApplyRepository {
     @Override
     public List<UserApply> findAllUserApplyByUserId(Long userId) {
         return userApplyJpaRepository.findByApplierId(userId);
+    }
+
+    @Override
+    public List<User> findApplicantsByYearSemester(int year, int semester, String search) {
+        return userApplyJpaRepository.findApplicantsByYearSemester(year, semester, search);
+    }
+
+    @Override
+    public boolean existsByApplierIdAndYearSemester(Long userId, int year, int semester) {
+        return userApplyJpaRepository.existsByApplierIdAndApplyYearAndApplySemester(userId, year, semester);
     }
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/user/UserRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/user/UserRepositoryImpl.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static org.forif_backend.domain.study.QStudy.study;
 import static org.forif_backend.domain.study.QStudyUser.studyUser;
+import static org.forif_backend.domain.dues.QMemberSemesterCheck.memberSemesterCheck;
 import static org.forif_backend.domain.user.QUser.user;
 import static org.forif_backend.domain.user.QUserApply.userApply;
 
@@ -226,6 +227,194 @@ public class UserRepositoryImpl implements UserRepository {
         return count != null ? count : 0L;
     }
 
+    @Override
+    public List<User> searchNotificationUsersWithCursor(Long cursor, int size, String search) {
+        return queryFactory
+                .selectFrom(user)
+                .where(
+                        userCursorLt(cursor),
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search)
+                )
+                .orderBy(user.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    @Override
+    public long countNotificationUsers(String search) {
+        Long count = queryFactory
+                .select(user.count())
+                .from(user)
+                .where(
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search)
+                )
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public List<User> searchNotificationUsersByYearSemester(int year, int semester, Long cursor, int size, String search) {
+        return queryFactory
+                .selectFrom(user).distinct()
+                .join(studyUser).on(studyUser.user.id.eq(user.id))
+                .join(study).on(studyUser.study.id.eq(study.id))
+                .where(
+                        study.actYear.eq(year),
+                        study.actSemester.eq(semester),
+                        userCursorLt(cursor),
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search)
+                )
+                .orderBy(user.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    @Override
+    public long countNotificationUsersByYearSemester(int year, int semester, String search) {
+        Long count = queryFactory
+                .select(user.countDistinct())
+                .from(user)
+                .join(studyUser).on(studyUser.user.id.eq(user.id))
+                .join(study).on(studyUser.study.id.eq(study.id))
+                .where(
+                        study.actYear.eq(year),
+                        study.actSemester.eq(semester),
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search)
+                )
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public List<User> searchApplicantsByYearSemester(int year, int semester, Long cursor, int size, String search) {
+        return queryFactory
+                .selectFrom(user).distinct()
+                .join(userApply).on(userApply.applier.id.eq(user.id))
+                .where(
+                        userApply.applyYear.eq(year),
+                        userApply.applySemester.eq(semester),
+                        userCursorLt(cursor),
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search)
+                )
+                .orderBy(user.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    @Override
+    public long countApplicantsByYearSemester(int year, int semester, String search) {
+        Long count = queryFactory
+                .select(user.countDistinct())
+                .from(user)
+                .join(userApply).on(userApply.applier.id.eq(user.id))
+                .where(
+                        userApply.applyYear.eq(year),
+                        userApply.applySemester.eq(semester),
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search)
+                )
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public List<User> searchAcceptedUsersMissingDuesByYearSemester(
+            int year, int semester, Long cursor, int size, String search
+    ) {
+        return searchAcceptedUsersWithIncompleteCheck(
+                year, semester, cursor, size, search,
+                memberSemesterCheck.id.isNull().or(memberSemesterCheck.duesPaid.isFalse())
+        );
+    }
+
+    @Override
+    public long countAcceptedUsersMissingDuesByYearSemester(int year, int semester, String search) {
+        return countAcceptedUsersWithIncompleteCheck(
+                year, semester, search,
+                memberSemesterCheck.id.isNull().or(memberSemesterCheck.duesPaid.isFalse())
+        );
+    }
+
+    @Override
+    public List<User> searchAcceptedUsersMissingGoogleFormByYearSemester(
+            int year, int semester, Long cursor, int size, String search
+    ) {
+        return searchAcceptedUsersWithIncompleteCheck(
+                year, semester, cursor, size, search,
+                memberSemesterCheck.id.isNull().or(memberSemesterCheck.googleFormSubmitted.isFalse())
+        );
+    }
+
+    @Override
+    public long countAcceptedUsersMissingGoogleFormByYearSemester(int year, int semester, String search) {
+        return countAcceptedUsersWithIncompleteCheck(
+                year, semester, search,
+                memberSemesterCheck.id.isNull().or(memberSemesterCheck.googleFormSubmitted.isFalse())
+        );
+    }
+
+    private List<User> searchAcceptedUsersWithIncompleteCheck(
+            int year,
+            int semester,
+            Long cursor,
+            int size,
+            String search,
+            BooleanExpression incompleteCheck
+    ) {
+        return queryFactory
+                .selectFrom(user).distinct()
+                .join(userApply).on(userApply.applier.id.eq(user.id))
+                .leftJoin(memberSemesterCheck).on(
+                        memberSemesterCheck.user.id.eq(user.id),
+                        memberSemesterCheck.actYear.eq(year),
+                        memberSemesterCheck.actSemester.eq(semester)
+                )
+                .where(
+                        userApply.applyYear.eq(year),
+                        userApply.applySemester.eq(semester),
+                        hasAcceptedStudyApplication(),
+                        userCursorLt(cursor),
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search),
+                        incompleteCheck
+                )
+                .orderBy(user.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    private long countAcceptedUsersWithIncompleteCheck(
+            int year,
+            int semester,
+            String search,
+            BooleanExpression incompleteCheck
+    ) {
+        Long count = queryFactory
+                .select(user.countDistinct())
+                .from(user)
+                .join(userApply).on(userApply.applier.id.eq(user.id))
+                .leftJoin(memberSemesterCheck).on(
+                        memberSemesterCheck.user.id.eq(user.id),
+                        memberSemesterCheck.actYear.eq(year),
+                        memberSemesterCheck.actSemester.eq(semester)
+                )
+                .where(
+                        userApply.applyYear.eq(year),
+                        userApply.applySemester.eq(semester),
+                        hasAcceptedStudyApplication(),
+                        hasPhoneNumber(),
+                        notificationRecipientSearchKeyword(search),
+                        incompleteCheck
+                )
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
     private BooleanExpression userCursorLt(Long cursor) {
         return cursor != null ? user.id.lt(cursor) : null;
     }
@@ -236,5 +425,22 @@ public class UserRepositoryImpl implements UserRepository {
         }
         return user.userName.containsIgnoreCase(search)
                 .or(user.department.containsIgnoreCase(search));
+    }
+
+    private BooleanExpression hasPhoneNumber() {
+        return user.phoneNum.isNotNull().and(user.phoneNum.ne(""));
+    }
+
+    private BooleanExpression hasAcceptedStudyApplication() {
+        return userApply.primaryStatus.eq(UserApplyStatus.ACCEPT)
+                .or(userApply.secondaryStatus.eq(UserApplyStatus.ACCEPT));
+    }
+
+    private BooleanExpression notificationRecipientSearchKeyword(String search) {
+        if (search == null || search.isBlank()) {
+            return null;
+        }
+        return user.userName.containsIgnoreCase(search)
+                .or(user.id.stringValue().contains(search));
     }
 }

--- a/src/main/java/org/forif_backend/web/dues/DuesController.java
+++ b/src/main/java/org/forif_backend/web/dues/DuesController.java
@@ -15,7 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "회비 관리", description = "현재 학기 부원의 회비·구글폼 제출 상태 관리 API")
+@Tag(name = "회비 관리", description = "현재 학기 부원·신청자의 회비·구글폼 제출 상태 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/dues")

--- a/src/main/java/org/forif_backend/web/notification/NotificationController.java
+++ b/src/main/java/org/forif_backend/web/notification/NotificationController.java
@@ -8,11 +8,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.forif_backend.application.notification.dto.SendAlimTalkCommand;
 import org.forif_backend.application.notification.dto.SendAlimTalkResult;
 import org.forif_backend.application.notification.dto.TemplateInfo;
+import org.forif_backend.application.notification.dto.NotificationRecipientTarget;
 import org.forif_backend.application.notification.NotificationService;
+import org.forif_backend.common.dto.response.CursorPageResponse;
 import org.forif_backend.common.dto.response.ApiResponse;
 import org.forif_backend.web.notification.dto.NotificationDtoMapper;
 import org.forif_backend.web.notification.dto.SendAlimTalkRequest;
 import org.forif_backend.web.notification.dto.SendAlimTalkResponse;
+import org.forif_backend.web.user.dto.MemberResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,6 +31,20 @@ import java.util.List;
 public class NotificationController {
 
     private final NotificationService notificationService;
+
+    @Operation(summary = "문자 발송 수신자 조회 (어드민 전용)")
+    @GetMapping("/receivers")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<CursorPageResponse<MemberResponse>>> getRecipients(
+            @RequestParam(name = "target_type", defaultValue = "CURRENT_SEMESTER_MEMBERS") NotificationRecipientTarget target,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "100") int size,
+            @RequestParam(required = false) String search
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                notificationService.getRecipients(target, cursor, size, search)
+        ));
+    }
 
     /**
      * 알림톡 발송

--- a/src/test/java/org/forif_backend/application/dues/DuesServiceTest.java
+++ b/src/test/java/org/forif_backend/application/dues/DuesServiceTest.java
@@ -8,8 +8,13 @@ import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.domain.dues.MemberSemesterCheck;
 import org.forif_backend.domain.dues.MemberSemesterCheckRepository;
 import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.study.StudyUser;
 import org.forif_backend.domain.study.StudyUserRepository;
 import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserApply;
+import org.forif_backend.domain.user.UserApplyRepository;
+import org.forif_backend.domain.user.UserApplyStatus;
 import org.forif_backend.domain.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +35,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class DuesServiceTest {
@@ -44,6 +50,8 @@ class DuesServiceTest {
     private StudyRepository studyRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private UserApplyRepository userApplyRepository;
     @Mock
     private MemberSemesterCheckRepository memberSemesterCheckRepository;
 
@@ -102,5 +110,97 @@ class DuesServiceTest {
         verify(memberSemesterCheckRepository).save(captor.capture());
         assertThat(captor.getValue().isDuesPaid()).isTrue();
         assertThat(captor.getValue().isGoogleFormSubmitted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("현재 학기 신청자는 수강생이 아니어도 회비 관리 대상에 포함한다")
+    void includesApplicantsWhoAreNotStudyMembers() {
+        User applicant = User.createUser(3L, "다라마바사", "applicant@hanyang.ac.kr", "01055556666", "소프트웨어학부");
+        when(studyUserRepository.findUsersByYearSemester(2026, 2, null))
+                .thenReturn(List.of(duesUnpaidUser));
+        when(userApplyRepository.findApplicantsByYearSemester(2026, 2, null))
+                .thenReturn(List.of(applicant));
+        when(memberSemesterCheckRepository.findAllByYearSemesterAndUserIds(2026, 2, List.of(1L, 3L)))
+                .thenReturn(List.of());
+        when(studyRepository.findCurrentStudyNamesByUserIds(anyList(), anyInt(), anyInt()))
+                .thenReturn(Map.of(1L, "웹 스터디"));
+
+        DuesPageResult result = duesService.getCurrentSemesterDues(0, 20, null, DuesSort.NAME);
+
+        assertThat(result.content()).extracting(member -> member.userId())
+                .containsExactly(1L, 3L);
+        assertThat(result.summary().totalCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("현재 학기 신청자는 수강생이 아니어도 회비 상태를 저장할 수 있다")
+    void updatesDuesForApplicantWhoIsNotStudyMember() {
+        when(studyUserRepository.existsByUserIdAndStudyYearSemester(1L, 2026, 2)).thenReturn(false);
+        when(userApplyRepository.existsByApplierIdAndYearSemester(1L, 2026, 2)).thenReturn(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(duesUnpaidUser));
+        when(memberSemesterCheckRepository.findByUserIdAndYearSemester(1L, 2026, 2))
+                .thenReturn(Optional.empty());
+        when(memberSemesterCheckRepository.save(any(MemberSemesterCheck.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        duesService.updateCurrentSemesterDuesBatch(List.of(
+                new UpdateDuesMemberCommand(1L, true, false)
+        ));
+
+        verify(memberSemesterCheckRepository).save(any(MemberSemesterCheck.class));
+    }
+
+    @Test
+    @DisplayName("합격자는 회비와 구글폼이 모두 확인될 때에만 수강생으로 등록한다")
+    void registersAcceptedApplicantOnlyWhenBothChecksAreComplete() {
+        Study acceptedStudy = mock(Study.class);
+        UserApply acceptedApplication = mock(UserApply.class);
+        MemberSemesterCheck completedCheck = MemberSemesterCheck.create(duesUnpaidUser, 2026, 2);
+        completedCheck.update(true, true);
+
+        when(studyUserRepository.existsByUserIdAndStudyYearSemester(1L, 2026, 2)).thenReturn(false);
+        when(userApplyRepository.existsByApplierIdAndYearSemester(1L, 2026, 2)).thenReturn(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(duesUnpaidUser));
+        when(memberSemesterCheckRepository.findByUserIdAndYearSemester(1L, 2026, 2))
+                .thenReturn(Optional.of(completedCheck));
+        when(userRepository.findUserApplyByYearAndSemesterAndUser(2026, 2, duesUnpaidUser))
+                .thenReturn(Optional.of(acceptedApplication));
+        when(acceptedApplication.getPrimaryStatus()).thenReturn(UserApplyStatus.ACCEPT);
+        when(acceptedApplication.getPrimaryStudy()).thenReturn(10);
+        when(studyRepository.findStudyById(10)).thenReturn(Optional.of(acceptedStudy));
+        when(acceptedStudy.getId()).thenReturn(10);
+        when(studyUserRepository.findByUserIdAndStudyId(1L, 10)).thenReturn(Optional.empty());
+
+        duesService.updateCurrentSemesterDuesBatch(List.of(
+                new UpdateDuesMemberCommand(1L, true, true)
+        ));
+
+        verify(studyUserRepository).save(any(StudyUser.class));
+    }
+
+    @Test
+    @DisplayName("확인 완료 후 회비 또는 구글폼 상태가 취소되면 수강생 등록을 해제한다")
+    void removesStudyMemberWhenARequiredCheckIsCancelled() {
+        Study acceptedStudy = mock(Study.class);
+        UserApply acceptedApplication = mock(UserApply.class);
+        MemberSemesterCheck completedCheck = MemberSemesterCheck.create(duesUnpaidUser, 2026, 2);
+        completedCheck.update(true, true);
+
+        when(studyUserRepository.existsByUserIdAndStudyYearSemester(1L, 2026, 2)).thenReturn(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(duesUnpaidUser));
+        when(memberSemesterCheckRepository.findByUserIdAndYearSemester(1L, 2026, 2))
+                .thenReturn(Optional.of(completedCheck));
+        when(userRepository.findUserApplyByYearAndSemesterAndUser(2026, 2, duesUnpaidUser))
+                .thenReturn(Optional.of(acceptedApplication));
+        when(acceptedApplication.getPrimaryStatus()).thenReturn(UserApplyStatus.ACCEPT);
+        when(acceptedApplication.getPrimaryStudy()).thenReturn(10);
+        when(studyRepository.findStudyById(10)).thenReturn(Optional.of(acceptedStudy));
+        when(acceptedStudy.getId()).thenReturn(10);
+
+        duesService.updateCurrentSemesterDuesBatch(List.of(
+                new UpdateDuesMemberCommand(1L, false, null)
+        ));
+
+        verify(studyUserRepository).deleteByUserIdAndStudyId(1L, 10);
     }
 }

--- a/src/test/java/org/forif_backend/application/notification/NotificationServiceRecipientTest.java
+++ b/src/test/java/org/forif_backend/application/notification/NotificationServiceRecipientTest.java
@@ -1,0 +1,116 @@
+package org.forif_backend.application.notification;
+
+import org.forif_backend.application.notification.port.out.NotificationSendPort;
+import org.forif_backend.application.notification.dto.NotificationRecipientTarget;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.application.user.UserService;
+import org.forif_backend.common.dto.response.CursorPageResponse;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.user.UserRepository;
+import org.forif_backend.web.user.dto.MemberResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceRecipientTest {
+
+    private static final CursorPageResponse<MemberResponse> EMPTY_PAGE =
+            CursorPageResponse.ofCursor(java.util.List.of(), null, false, 0);
+
+    @Mock
+    private NotificationSendPort notificationSendPort;
+    @Mock
+    private StaffAccountRepository staffAccountRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private SemesterService semesterService;
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 1));
+    }
+
+    @Test
+    void getsCurrentSemesterMembers() {
+        when(userService.getNotificationMembers(2026, 1, null, 100, "김"))
+                .thenReturn(EMPTY_PAGE);
+
+        CursorPageResponse<MemberResponse> result = notificationService.getRecipients(
+                NotificationRecipientTarget.CURRENT_SEMESTER_MEMBERS, null, 100, "김");
+
+        assertThat(result).isSameAs(EMPTY_PAGE);
+    }
+
+    @Test
+    void getsCurrentSemesterApplicantsRegardlessOfAcceptanceStatus() {
+        when(userService.getApplicants(2026, 1, null, 100, "김"))
+                .thenReturn(EMPTY_PAGE);
+
+        CursorPageResponse<MemberResponse> result = notificationService.getRecipients(
+                NotificationRecipientTarget.CURRENT_SEMESTER_APPLICANTS, null, 100, "김");
+
+        assertThat(result).isSameAs(EMPTY_PAGE);
+    }
+
+    @Test
+    void getsPreviousSemesterMembersAcrossYearBoundary() {
+        when(userService.getNotificationMembers(2025, 2, null, 100, "김"))
+                .thenReturn(EMPTY_PAGE);
+
+        CursorPageResponse<MemberResponse> result = notificationService.getRecipients(
+                NotificationRecipientTarget.PREVIOUS_SEMESTER_MEMBERS, null, 100, "김");
+
+        assertThat(result).isSameAs(EMPTY_PAGE);
+        verify(userService).getNotificationMembers(eq(2025), eq(2), isNull(), eq(100), eq("김"));
+    }
+
+    @Test
+    void getsAllMembers() {
+        when(userService.getNotificationMembers(null, 100, "김"))
+                .thenReturn(EMPTY_PAGE);
+
+        CursorPageResponse<MemberResponse> result = notificationService.getRecipients(
+                NotificationRecipientTarget.ALL_MEMBERS, null, 100, "김");
+
+        assertThat(result).isSameAs(EMPTY_PAGE);
+    }
+
+    @Test
+    void getsAcceptedUsersWhoHaveNotPaidDues() {
+        when(userService.getAcceptedUsersMissingDues(2026, 1, null, 100, "김"))
+                .thenReturn(EMPTY_PAGE);
+
+        CursorPageResponse<MemberResponse> result = notificationService.getRecipients(
+                NotificationRecipientTarget.ACCEPTED_DUES_UNPAID, null, 100, "김");
+
+        assertThat(result).isSameAs(EMPTY_PAGE);
+    }
+
+    @Test
+    void getsAcceptedUsersWhoHaveNotSubmittedGoogleForm() {
+        when(userService.getAcceptedUsersMissingGoogleForm(2026, 1, null, 100, "김"))
+                .thenReturn(EMPTY_PAGE);
+
+        CursorPageResponse<MemberResponse> result = notificationService.getRecipients(
+                NotificationRecipientTarget.ACCEPTED_GOOGLE_FORM_NOT_SUBMITTED, null, 100, "김");
+
+        assertThat(result).isSameAs(EMPTY_PAGE);
+    }
+}

--- a/src/test/java/org/forif_backend/application/user/UserApplyServiceAcceptanceTest.java
+++ b/src/test/java/org/forif_backend/application/user/UserApplyServiceAcceptanceTest.java
@@ -1,0 +1,66 @@
+package org.forif_backend.application.user;
+
+import org.forif_backend.application.dues.DuesService;
+import org.forif_backend.application.semester.SemesterPhaseGuard;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.study.StudyMentorAccess;
+import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.StudyUserRepository;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserApply;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserApplyServiceAcceptanceTest {
+
+    @Mock
+    private SemesterService semesterService;
+    @Mock
+    private SemesterPhaseGuard semesterPhaseGuard;
+    @Mock
+    private StudyMentorAccess studyMentorAccess;
+    @Mock
+    private DuesService duesService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private StudyRepository studyRepository;
+    @Mock
+    private StudyUserRepository studyUserRepository;
+
+    @InjectMocks
+    private UserApplyService userApplyService;
+
+    @Test
+    void acceptsApplicationWithoutDirectlyCreatingStudyUser() {
+        Study study = mock(Study.class);
+        User applicant = User.createUser(1L, "신청자", "applicant@hanyang.ac.kr", "01011112222", "컴퓨터학부");
+        UserApply application = mock(UserApply.class);
+
+        when(studyRepository.findStudyById(10)).thenReturn(Optional.of(study));
+        when(userRepository.findUserApplyById(100L)).thenReturn(application);
+        when(application.getPrimaryStudy()).thenReturn(10);
+        when(application.getApplier()).thenReturn(applicant);
+
+        userApplyService.acceptApplications(99L, 10, List.of(100L));
+
+        verify(application).updateStatus(10, org.forif_backend.domain.user.UserApplyStatus.ACCEPT);
+        verify(duesService).ensureMemberCheck(study, applicant);
+        verify(duesService).registerStudyUserIfEligible(study, applicant);
+        verify(studyUserRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}


### PR DESCRIPTION
feat(member): 회비 관리 및 문자 발송 대상 기준을 개편

회비 관리 대상에 현재 학기 스터디 수강생뿐 아니라
현재 학기 스터디 신청자를 포함하도록 변경했습니다.
수강생과 신청자는 사용자 ID 기준으로 중복 없이 관리하며,
신청자도 회비 납부·구글폼 제출 상태를 저장할 수 있습니다.

스터디 합격 처리 시 즉시 수강생을 생성하던 흐름을 변경했습니다.
합격 상태인 신청자 중 회비 납부와 구글폼 제출이 모두 확인된 경우에만
StudyUser를 생성하도록 했습니다.
두 조건 중 하나라도 미확인 상태로 변경되면 해당 수강생 등록을 해제합니다.
합격 전에 두 조건이 이미 확인된 경우에는 합격 처리 직후 등록됩니다.

문자 발송 수신자 조회 API를 추가하고 대상 유형을 확장했습니다.

- 현재 학기 부원
- 현재 학기 신청자
- 회비 미납 합격자
- 구글폼 미제출 합격자
- 직전 학기 부원
- 전체 부원

수신자 검색은 선택한 대상 유형 내부에서 이름 또는 학번으로만 수행합니다.
휴대폰 번호가 없거나 빈 사용자는 수신자 목록과 총 인원에서 제외했습니다.
수신자 조회 페이지 크기는 서버에서 최대 100명으로 제한했습니다.

테스트:
- 회비·구글폼 확인 여부에 따른 수강생 등록/해제 검증
- 합격 처리 시 직접 수강생을 생성하지 않는지 검증
- 문자 발송 대상 유형별 조회 분기 검증
- 백엔드 전체 테스트 통과