### PR TITLE
(admin): 운영진 계정과 현재 학기 부원 삭제 기능 지원

### DIFF
--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -293,7 +293,7 @@ public class StaffAccountService {
     /**
      * 대상 운영진 조회 + 권한 검증 (공통)
      * - ADMIN role 확인
-     * - 부회장 대상은 회장만 관리 가능
+     * - 회장은 위임 절차 없이 삭제할 수 없고, 부회장 대상은 회장만 관리 가능
      * - 자기 자신은 관리 불가
      */
     private StaffAccount findAndValidateTargetAdmin(StaffAccount requester, Long targetUserId) {
@@ -303,6 +303,10 @@ public class StaffAccountService {
 
         StaffAccount target = staffAccountRepository.findByUserIdAndRole(targetUserId, StaffRole.ADMIN)
                 .orElseThrow(() -> new ForifException(ErrorCode.STAFF_NOT_FOUND));
+
+        if ("회장".equals(target.getAffiliation())) {
+            throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
+        }
 
         if ("부회장".equals(target.getAffiliation()) && !"회장".equals(requester.getAffiliation())) {
             throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
@@ -345,6 +349,7 @@ public class StaffAccountService {
         StaffAccount target = findAndValidateTargetAdmin(requester, targetUserId);
 
         staffAccountRepository.delete(target);
+        refreshTokenService.deleteRefreshToken(targetUserId.toString(), StaffRole.ADMIN.getValue());
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/user/UserService.java
+++ b/src/main/java/org/forif_backend/application/user/UserService.java
@@ -425,6 +425,25 @@ public class UserService {
         return CursorPageResponse.ofCursor(responses, nextCursor != null ? nextCursor.intValue() : null, hasNext, totalElements);
     }
 
+    /**
+     * 현재 활동 학기 부원 명단에서 제외한다.
+     * User 계정과 지난 학기 수강 이력은 보존하며, 현재 학기의 수강 관계만 하드 삭제한다.
+     */
+    @Transactional
+    public void deleteCurrentSemesterMember(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new ForifException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        SemesterInfo active = semesterService.getActive();
+        int deletedCount = studyUserRepository.deleteByUserIdAndStudyYearSemester(
+                userId, active.actYear(), active.actSemester());
+
+        if (deletedCount == 0) {
+            throw new ForifException(ErrorCode.CURRENT_SEMESTER_MEMBER_NOT_FOUND);
+        }
+    }
+
     private List<MemberResponse> buildMemberResponses(List<User> users, int year, int semester) {
         List<Long> userIds = users.stream().map(User::getId).toList();
 

--- a/src/main/java/org/forif_backend/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/forif_backend/common/auth/JwtAuthenticationFilter.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import org.forif_backend.application.auth.TokenBlacklistService;
 import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.staff.StaffRole;
 
 /**
  * JWT 토큰 기반 인증을 처리하는 Spring Security 필터
@@ -39,6 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final TokenBlacklistService tokenBlacklistService;
+    private final StaffAccountRepository staffAccountRepository;
     private static final String BEARER_PREFIX = "Bearer ";
     private static final int BEARER_PREFIX_LENGTH = 7;
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
@@ -113,6 +116,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
 
+                // 운영진/멘토 계정이 삭제된 뒤에는 만료 전 access token도 더 이상 권한을 갖지 않는다.
+                if (!isActiveStaffAccount(token)) {
+                    log.warn("삭제된 스태프 계정의 토큰입니다. URI: {}", request.getRequestURI());
+                    request.setAttribute("jwt.error", ErrorCode.INVALID_TOKEN);
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 // 7. 토큰에서 사용자 ID 추출 및 인증 정보 설정
                 setAuthentication(token, request);
                 log.debug("JWT 인증 성공. ID: {}", jwtProvider.getUserIdFromToken(token));
@@ -152,6 +163,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        }
+
+        private boolean isActiveStaffAccount(String token) {
+            String role = jwtProvider.getRoleFromToken(token);
+            if ("USER".equals(role)) {
+                return true;
+            }
+
+            try {
+                Long userId = Long.parseLong(jwtProvider.getUserIdFromToken(token));
+                StaffRole staffRole = StaffRole.fromValue(role);
+                return staffAccountRepository.existsByUserIdAndRole(userId, staffRole);
+            } catch (Exception e) {
+                return false;
+            }
         }
 
         private List<SimpleGrantedAuthority> resolveAuthorities(String role) {

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -86,6 +86,7 @@ public enum ErrorCode {
     HACKATHON_EVALUATION_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR072-404", "해커톤 평가를 찾을 수 없습니다."),
     HACKATHON_AWARD_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR073-404", "해커톤 수상 결과를 찾을 수 없습니다."),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR077-404", "파일을 찾을 수 없습니다."),
+    CURRENT_SEMESTER_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR128-404", "현재 활동 학기에 등록된 부원이 아닙니다."),
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR044-409", "이미 가입된 사용자입니다."),

--- a/src/main/java/org/forif_backend/domain/study/StudyUserRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyUserRepository.java
@@ -18,6 +18,9 @@ public interface StudyUserRepository {
 
     void deleteByUserIdAndStudyId(Long userId, Integer studyId);
 
+    /** 현재 활동 학기에서 부원을 제외할 때, 해당 학기의 모든 수강 관계를 삭제한다. */
+    int deleteByUserIdAndStudyYearSemester(Long userId, int year, int semester);
+
     boolean existsByUserIdAndStudyYearSemester(Long userId, int year, int semester);
 
     /** 해당 학기 수강생 수 (수료증 발급 현황 안내용) */

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserJpaRepository.java
@@ -4,6 +4,7 @@ import org.forif_backend.domain.study.StudyUser;
 import org.forif_backend.domain.study.StudyUserId;
 import org.forif_backend.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -58,6 +59,17 @@ public interface StudyUserJpaRepository extends JpaRepository<StudyUser, StudyUs
     void deleteByStudyId(Integer studyId);
 
     void deleteByUserIdAndStudyId(Long userId, Integer studyId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            DELETE FROM StudyUser su
+            WHERE su.user.id = :userId
+              AND su.study.actYear = :year
+              AND su.study.actSemester = :semester
+            """)
+    int deleteByUserIdAndStudyYearSemester(@Param("userId") Long userId,
+                                           @Param("year") int year,
+                                           @Param("semester") int semester);
 
     @Query("""
             SELECT CASE WHEN COUNT(su) > 0 THEN true ELSE false END

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyUserRepositoryImpl.java
@@ -46,6 +46,11 @@ public class StudyUserRepositoryImpl implements StudyUserRepository {
     }
 
     @Override
+    public int deleteByUserIdAndStudyYearSemester(Long userId, int year, int semester) {
+        return studyUserJpaRepository.deleteByUserIdAndStudyYearSemester(userId, year, semester);
+    }
+
+    @Override
     public long countBySemester(int year, int semester) {
         return studyUserJpaRepository.countBySemester(year, semester);
     }

--- a/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
+++ b/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
@@ -307,4 +307,18 @@ public class StaffAccountController {
     ) {
         return ResponseEntity.ok(ApiResponse.success(userService.getAllMembers(year, semester, cursor, page, size, search)));
     }
+
+    /**
+     * [운영진 전용] 현재 활동 학기 부원 삭제
+     */
+    @Operation(summary = "현재 학기 부원 삭제 (어드민 전용)",
+            description = "부원 계정과 과거 학기 이력은 보존하고, 현재 활동 학기의 수강 관계만 하드 삭제합니다.")
+    @DeleteMapping("/api/v1/admin/users/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> deleteCurrentSemesterMember(
+            @Parameter(description = "현재 활동 학기에서 삭제할 부원의 유저 ID") @PathVariable Long userId
+    ) {
+        userService.deleteCurrentSemesterMember(userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/test/java/org/forif_backend/application/staff/StaffAccountServiceDeleteAdminTest.java
+++ b/src/test/java/org/forif_backend/application/staff/StaffAccountServiceDeleteAdminTest.java
@@ -1,0 +1,88 @@
+package org.forif_backend.application.staff;
+
+import org.forif_backend.application.auth.RefreshTokenService;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.common.auth.JwtProvider;
+import org.forif_backend.domain.staff.StaffAccount;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.staff.StaffRole;
+import org.forif_backend.domain.team.ForifTeamRepository;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+
+@ExtendWith(MockitoExtension.class)
+class StaffAccountServiceDeleteAdminTest {
+
+    private static final Long REQUESTER_ID = 20260001L;
+    private static final Long TARGET_ID = 20260002L;
+
+    @Mock
+    private SemesterService semesterService;
+    @Mock
+    private StaffAccountRepository staffAccountRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private RefreshTokenService refreshTokenService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ForifTeamRepository forifTeamRepository;
+    @InjectMocks
+    private StaffAccountService staffAccountService;
+
+    @Test
+    void deletesAdminAccountAndInvalidatesItsAdminRefreshToken() {
+        StaffAccount requester = adminAccount(REQUESTER_ID, "회장");
+        StaffAccount target = adminAccount(TARGET_ID, "운영진");
+        when(staffAccountRepository.findByUserIdAndRole(REQUESTER_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(requester));
+        when(staffAccountRepository.findByUserIdAndRole(TARGET_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(target));
+
+        staffAccountService.deleteAdmin(REQUESTER_ID, TARGET_ID);
+
+        verify(staffAccountRepository).delete(target);
+        verify(refreshTokenService).deleteRefreshToken(TARGET_ID.toString(), StaffRole.ADMIN.getValue());
+    }
+
+    @Test
+    void vicePresidentCannotDeletePresident() {
+        StaffAccount requester = adminAccount(REQUESTER_ID, "부회장");
+        StaffAccount target = adminAccount(TARGET_ID, "회장");
+        when(staffAccountRepository.findByUserIdAndRole(REQUESTER_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(requester));
+        when(staffAccountRepository.findByUserIdAndRole(TARGET_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(target));
+
+        ForifException exception = assertThrows(
+                ForifException.class,
+                () -> staffAccountService.deleteAdmin(REQUESTER_ID, TARGET_ID));
+
+        assertEquals(ErrorCode.INSUFFICIENT_PERMISSION, exception.getErrorCode());
+        verify(staffAccountRepository, never()).delete(target);
+    }
+
+    private StaffAccount adminAccount(Long userId, String affiliation) {
+        User user = User.createUser(userId, "운영진", userId + "@hanyang.ac.kr", "010-0000-0000", "컴퓨터학부");
+        return StaffAccount.createStaffAccount(user, "encoded-password", "운영진", StaffRole.ADMIN, affiliation);
+    }
+}

--- a/src/test/java/org/forif_backend/application/user/UserServiceMemberDeletionTest.java
+++ b/src/test/java/org/forif_backend/application/user/UserServiceMemberDeletionTest.java
@@ -1,0 +1,81 @@
+package org.forif_backend.application.user;
+
+import org.forif_backend.application.auth.RefreshTokenService;
+import org.forif_backend.application.file.port.out.FilePort;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
+import org.forif_backend.common.auth.JwtProvider;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.StudyUserRepository;
+import org.forif_backend.domain.user.GoogleOAuthClient;
+import org.forif_backend.domain.user.UserApplyRepository;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceMemberDeletionTest {
+
+    private static final Long USER_ID = 20260001L;
+
+    @Mock
+    private SemesterService semesterService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserApplyRepository userApplyRepository;
+    @Mock
+    private StudyRepository studyRepository;
+    @Mock
+    private StudyUserRepository studyUserRepository;
+    @Mock
+    private StaffAccountRepository staffAccountRepository;
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private GoogleOAuthClient googleOAuthClient;
+    @Mock
+    private RefreshTokenService refreshTokenService;
+    @Mock
+    private FilePort filePort;
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void deletesOnlyTheCurrentSemesterStudyMemberships() {
+        SemesterInfo activeSemester = SemesterInfo.of(2026, 2);
+        when(userRepository.existsById(USER_ID)).thenReturn(true);
+        when(semesterService.getActive()).thenReturn(activeSemester);
+        when(studyUserRepository.deleteByUserIdAndStudyYearSemester(USER_ID, 2026, 2)).thenReturn(2);
+
+        userService.deleteCurrentSemesterMember(USER_ID);
+
+        verify(studyUserRepository).deleteByUserIdAndStudyYearSemester(USER_ID, 2026, 2);
+        verify(userRepository, never()).deleteById(USER_ID);
+    }
+
+    @Test
+    void rejectsDeletionWhenTheUserIsNotInTheCurrentSemester() {
+        when(userRepository.existsById(USER_ID)).thenReturn(true);
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
+        when(studyUserRepository.deleteByUserIdAndStudyYearSemester(USER_ID, 2026, 2)).thenReturn(0);
+
+        ForifException exception = assertThrows(
+                ForifException.class,
+                () -> userService.deleteCurrentSemesterMember(USER_ID));
+
+        assertEquals(ErrorCode.CURRENT_SEMESTER_MEMBER_NOT_FOUND, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
운영진 계정 삭제 시 ADMIN 계정·refresh token을 삭제하고, 기존 access token도 즉시 무효화
회장 계정 삭제 차단 및 회장단 권한 규칙 보강
현재 활동 학기 부원 삭제 API 추가현재 학기 수강 관계만 하드 삭제
사용자 계정·이전 학기 이력은 유지

admin 부원 목록에서 현재 학기 탭에만 삭제 UI·확인 안내 추가
운영진 계정 삭제 안내에 보존되는 데이터 명시
백엔드 삭제 로직 단위 테스트 추가