### PR TITLE
fix(auth,user): 계정 삭제 기능의 장애 확산과 복구 불가 문제 해소

### DIFF
--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -293,8 +293,12 @@ public class StaffAccountService {
     /**
      * 대상 운영진 조회 + 권한 검증 (공통)
      * - ADMIN role 확인
-     * - 회장은 위임 절차 없이 삭제할 수 없고, 부회장 대상은 회장만 관리 가능
+     * - 부회장 대상은 회장만 관리 가능
      * - 자기 자신은 관리 불가
+     *
+     * 회장 보호는 여기 두지 않는다. 이 헬퍼는 수정도 함께 쓰기 때문에, 여기서 막으면
+     * 회장 비밀번호 재설정까지 불가능해진다. 요청자는 자기 자신을 관리할 수 없어
+     * 회장 본인도 못 바꾸고, 부회장은 권한이 없어 아무도 손댈 수 없게 된다.
      */
     private StaffAccount findAndValidateTargetAdmin(StaffAccount requester, Long targetUserId) {
         if (requester.getUserId().equals(targetUserId)) {
@@ -303,10 +307,6 @@ public class StaffAccountService {
 
         StaffAccount target = staffAccountRepository.findByUserIdAndRole(targetUserId, StaffRole.ADMIN)
                 .orElseThrow(() -> new ForifException(ErrorCode.STAFF_NOT_FOUND));
-
-        if ("회장".equals(target.getAffiliation())) {
-            throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
-        }
 
         if ("부회장".equals(target.getAffiliation()) && !"회장".equals(requester.getAffiliation())) {
             throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
@@ -341,12 +341,17 @@ public class StaffAccountService {
     }
 
     /**
-     * 운영진 계정 삭제
+     * 운영진 계정 삭제.
+     * 회장은 삭제할 수 없다. 지우려면 먼저 차기 회장에게 위임해야 한다.
      */
     @Transactional
     public void deleteAdmin(Long requesterId, Long targetUserId) {
         StaffAccount requester = validatePresidentTeam(requesterId);
         StaffAccount target = findAndValidateTargetAdmin(requester, targetUserId);
+
+        if ("회장".equals(target.getAffiliation())) {
+            throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
+        }
 
         staffAccountRepository.delete(target);
         refreshTokenService.deleteRefreshToken(targetUserId.toString(), StaffRole.ADMIN.getValue());

--- a/src/main/java/org/forif_backend/application/user/UserService.java
+++ b/src/main/java/org/forif_backend/application/user/UserService.java
@@ -428,12 +428,16 @@ public class UserService {
     /**
      * 현재 활동 학기 부원 명단에서 제외한다.
      * User 계정과 지난 학기 수강 이력은 보존하며, 현재 학기의 수강 관계만 하드 삭제한다.
+     *
+     * 수강 관계만 지우면 삭제가 유지되지 않는다. 지원서가 합격 상태로 남아 있는 한
+     * 회비 확인 시 그 지원서를 근거로 수강생이 다시 등록되기 때문이다(DuesService).
+     * 그래서 지원서의 합격도 함께 되돌린다. 이렇게 해야 멘토가 다시 합격시켜 복구하는
+     * 정상 경로도 열린다.
      */
     @Transactional
     public void deleteCurrentSemesterMember(Long userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new ForifException(ErrorCode.USER_NOT_FOUND);
-        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
 
         SemesterInfo active = semesterService.getActive();
         int deletedCount = studyUserRepository.deleteByUserIdAndStudyYearSemester(
@@ -442,6 +446,13 @@ public class UserService {
         if (deletedCount == 0) {
             throw new ForifException(ErrorCode.CURRENT_SEMESTER_MEMBER_NOT_FOUND);
         }
+
+        userRepository.findUserApplyByYearAndSemesterAndUser(active.actYear(), active.actSemester(), user)
+                .ifPresent(UserApply::revertAcceptance);
+
+        // 되돌릴 수 없는 삭제이고 운영진 누구나 호출할 수 있으므로 흔적을 남긴다
+        log.info("현재 학기 부원 명단 삭제: userId={}, {}년 {}학기, 수강관계 {}건",
+                userId, active.actYear(), active.actSemester(), deletedCount);
     }
 
     /** 현재 학기 스터디 합격 여부와 관계없이 해당 학기에 스터디를 신청한 사용자 목록 조회 */

--- a/src/main/java/org/forif_backend/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/forif_backend/common/auth/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
@@ -128,6 +129,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 setAuthentication(token, request);
                 log.debug("JWT 인증 성공. ID: {}", jwtProvider.getUserIdFromToken(token));
 
+            } catch (DataAccessException e) {
+                // 조회가 실패한 것과 권한이 없는 것은 다르다. 여기서 삼키면 순간적인 DB 장애가
+                // 인증 실패로 둔갑해 운영진 전원이 로그아웃된다. 500으로 드러내는 편이 낫다.
+                log.error("인증 확인 중 DB 접근 실패. URI: {}", request.getRequestURI(), e);
+                throw new ServletException("인증 확인 중 데이터 접근에 실패했습니다", e);
             } catch (Exception e) {
                 log.error("JWT 인증 실패: {}", e.getMessage(), e);
             }
@@ -165,19 +171,29 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
         }
 
+        /**
+         * 스태프 계정이 아직 살아 있는지 확인한다.
+         *
+         * 멘토는 검사하지 않는다. 멘토 권한은 계정이 아니라 tb_study의 멘토 관계에서
+         * 유도되므로(FOR-116), 여기서 tb_staff_account 존재를 요구하면 멘토 계정 정리 시
+         * 로그인 중인 멘토가 전부 끊긴다.
+         *
+         * DB 예외는 삼키지 않는다. 조회가 실패한 것과 계정이 없는 것은 다르다.
+         * 이를 false로 뭉개면 순간적인 DB 장애가 운영진 전원 강제 로그아웃으로 번진다.
+         */
         private boolean isActiveStaffAccount(String token) {
             String role = jwtProvider.getRoleFromToken(token);
-            if ("USER".equals(role)) {
+            if (!"ADMIN".equals(role)) {
                 return true;
             }
 
+            Long userId;
             try {
-                Long userId = Long.parseLong(jwtProvider.getUserIdFromToken(token));
-                StaffRole staffRole = StaffRole.fromValue(role);
-                return staffAccountRepository.existsByUserIdAndRole(userId, staffRole);
-            } catch (Exception e) {
-                return false;
+                userId = Long.parseLong(jwtProvider.getUserIdFromToken(token));
+            } catch (NumberFormatException e) {
+                return false;   // 토큰이 망가진 경우
             }
+            return staffAccountRepository.existsByUserIdAndRole(userId, StaffRole.ADMIN);
         }
 
         private List<SimpleGrantedAuthority> resolveAuthorities(String role) {

--- a/src/main/java/org/forif_backend/domain/user/UserApply.java
+++ b/src/main/java/org/forif_backend/domain/user/UserApply.java
@@ -71,6 +71,21 @@ public class UserApply extends BaseTimeEntity {
         }
     }
 
+    /**
+     * 합격 상태를 되돌린다. 부원을 명단에서 뺄 때 함께 호출한다.
+     *
+     * ACCEPT를 남겨두면 멘토가 다시 합격 처리해도 이미 승낙 상태라 걸러져 수강생이 복구되지 않고,
+     * 회비 확인 시 이 지원서를 근거로 수강생이 되살아난다.
+     */
+    public void revertAcceptance() {
+        if (this.primaryStatus == UserApplyStatus.ACCEPT) {
+            this.primaryStatus = UserApplyStatus.REJECT;
+        }
+        if (this.secondaryStatus == UserApplyStatus.ACCEPT) {
+            this.secondaryStatus = UserApplyStatus.REJECT;
+        }
+    }
+
     public void addSecondaryStudy(Integer studyId, String studyName, String intro) {
         this.secondaryStudy = studyId;
         this.secondaryStudyName = studyName;

--- a/src/test/java/org/forif_backend/application/user/UserServiceMemberDeletionTest.java
+++ b/src/test/java/org/forif_backend/application/user/UserServiceMemberDeletionTest.java
@@ -8,10 +8,14 @@ import org.forif_backend.common.auth.JwtProvider;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.study.Study;
 import org.forif_backend.domain.study.StudyRepository;
 import org.forif_backend.domain.study.StudyUserRepository;
 import org.forif_backend.domain.user.GoogleOAuthClient;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserApply;
 import org.forif_backend.domain.user.UserApplyRepository;
+import org.forif_backend.domain.user.UserApplyStatus;
 import org.forif_backend.domain.user.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,8 +23,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -50,15 +59,18 @@ class UserServiceMemberDeletionTest {
     private RefreshTokenService refreshTokenService;
     @Mock
     private FilePort filePort;
+    @Mock
+    private User user;
     @InjectMocks
     private UserService userService;
 
     @Test
     void deletesOnlyTheCurrentSemesterStudyMemberships() {
         SemesterInfo activeSemester = SemesterInfo.of(2026, 2);
-        when(userRepository.existsById(USER_ID)).thenReturn(true);
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(semesterService.getActive()).thenReturn(activeSemester);
         when(studyUserRepository.deleteByUserIdAndStudyYearSemester(USER_ID, 2026, 2)).thenReturn(2);
+        when(userRepository.findUserApplyByYearAndSemesterAndUser(2026, 2, user)).thenReturn(Optional.empty());
 
         userService.deleteCurrentSemesterMember(USER_ID);
 
@@ -66,9 +78,30 @@ class UserServiceMemberDeletionTest {
         verify(userRepository, never()).deleteById(USER_ID);
     }
 
+    /**
+     * 합격 상태를 남겨두면 회비 확인 시 그 지원서를 근거로 수강생이 되살아나고,
+     * 멘토가 다시 합격시켜 복구하는 정상 경로도 막힌다.
+     */
+    @Test
+    void revertsTheAcceptanceSoTheDeletionSticks() {
+        Study study = org.mockito.Mockito.mock(Study.class);
+        when(study.getId()).thenReturn(100);
+        UserApply apply = UserApply.applyStudy(user, study, "지원 사유", 2026, 2);
+        apply.updateStatus(100, UserApplyStatus.ACCEPT);
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
+        when(studyUserRepository.deleteByUserIdAndStudyYearSemester(USER_ID, 2026, 2)).thenReturn(1);
+        when(userRepository.findUserApplyByYearAndSemesterAndUser(2026, 2, user)).thenReturn(Optional.of(apply));
+
+        userService.deleteCurrentSemesterMember(USER_ID);
+
+        assertThat(apply.getPrimaryStatus()).isEqualTo(UserApplyStatus.REJECT);
+    }
+
     @Test
     void rejectsDeletionWhenTheUserIsNotInTheCurrentSemester() {
-        when(userRepository.existsById(USER_ID)).thenReturn(true);
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 2));
         when(studyUserRepository.deleteByUserIdAndStudyYearSemester(USER_ID, 2026, 2)).thenReturn(0);
 
@@ -77,5 +110,18 @@ class UserServiceMemberDeletionTest {
                 () -> userService.deleteCurrentSemesterMember(USER_ID));
 
         assertEquals(ErrorCode.CURRENT_SEMESTER_MEMBER_NOT_FOUND, exception.getErrorCode());
+        verify(userRepository, never()).findUserApplyByYearAndSemesterAndUser(anyInt(), anyInt(), any());
+    }
+
+    @Test
+    void rejectsDeletionWhenTheUserDoesNotExist() {
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        ForifException exception = assertThrows(
+                ForifException.class,
+                () -> userService.deleteCurrentSemesterMember(USER_ID));
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(studyUserRepository, never()).deleteByUserIdAndStudyYearSemester(any(), anyInt(), anyInt());
     }
 }

--- a/src/test/java/org/forif_backend/common/auth/JwtAuthenticationFilterStaffCheckTest.java
+++ b/src/test/java/org/forif_backend/common/auth/JwtAuthenticationFilterStaffCheckTest.java
@@ -1,0 +1,130 @@
+package org.forif_backend.common.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.forif_backend.application.auth.TokenBlacklistService;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.staff.StaffRole;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 삭제된 스태프 계정의 access token 을 막는 검사(FOR-123)의 경계 동작.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JwtAuthenticationFilterStaffCheckTest {
+
+    private static final String TOKEN = "test-token";
+    private static final Long USER_ID = 20240001L;
+
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
+    @Mock
+    private StaffAccountRepository staffAccountRepository;
+    @InjectMocks
+    private JwtAuthenticationFilter filter;
+
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+    private final HttpServletResponse response = mock(HttpServletResponse.class);
+    private final FilterChain chain = mock(FilterChain.class);
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void givenAdminToken() {
+        when(request.getServletPath()).thenReturn("/api/v1/admin/users");
+        when(request.getRequestURI()).thenReturn("/api/v1/admin/users");
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + TOKEN);
+        when(jwtProvider.isTokenExpired(TOKEN)).thenReturn(false);
+        when(jwtProvider.validateToken(TOKEN)).thenReturn(true);
+        when(jwtProvider.isAccessToken(TOKEN)).thenReturn(true);
+        when(tokenBlacklistService.isTokenBlacklisted(TOKEN)).thenReturn(false);
+        when(jwtProvider.getRoleFromToken(TOKEN)).thenReturn("ADMIN");
+        when(jwtProvider.getUserIdFromToken(TOKEN)).thenReturn(USER_ID.toString());
+    }
+
+    @Test
+    void 삭제된_운영진_토큰은_인증되지_않는다() throws Exception {
+        givenAdminToken();
+        when(staffAccountRepository.existsByUserIdAndRole(USER_ID, StaffRole.ADMIN)).thenReturn(false);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(request).setAttribute("jwt.error", org.forif_backend.common.exception.ErrorCode.INVALID_TOKEN);
+    }
+
+    /**
+     * DB 장애를 "계정 없음"으로 뭉개면 순간적인 커넥션 문제가 운영진 전원 강제 로그아웃으로 번진다.
+     * 401이 아니라 예외로 전파되어야 한다.
+     */
+    @Test
+    void DB_장애는_삼키지_않고_전파한다() {
+        givenAdminToken();
+        when(staffAccountRepository.existsByUserIdAndRole(USER_ID, StaffRole.ADMIN))
+                .thenThrow(new QueryTimeoutException("connection pool exhausted"));
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, chain))
+                .isInstanceOf(jakarta.servlet.ServletException.class)
+                .hasCauseInstanceOf(QueryTimeoutException.class);
+    }
+
+    /**
+     * 멘토 권한은 계정이 아니라 tb_study의 멘토 관계에서 유도된다(FOR-116).
+     * 여기서 스태프 계정을 요구하면 멘토 계정 정리 시 로그인 중인 멘토가 전부 끊긴다.
+     */
+    @Test
+    void 멘토_토큰은_스태프_계정을_조회하지_않는다() throws Exception {
+        when(request.getServletPath()).thenReturn("/api/v1/studies/1/attendance");
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + TOKEN);
+        when(jwtProvider.isTokenExpired(TOKEN)).thenReturn(false);
+        when(jwtProvider.validateToken(TOKEN)).thenReturn(true);
+        when(jwtProvider.isAccessToken(TOKEN)).thenReturn(true);
+        when(tokenBlacklistService.isTokenBlacklisted(TOKEN)).thenReturn(false);
+        when(jwtProvider.getRoleFromToken(TOKEN)).thenReturn("MENTOR");
+        when(jwtProvider.getUserIdFromToken(TOKEN)).thenReturn(USER_ID.toString());
+
+        filter.doFilter(request, response, chain);
+
+        verify(staffAccountRepository, never()).existsByUserIdAndRole(USER_ID, StaffRole.MENTOR);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+    }
+
+    @Test
+    void 일반_부원_토큰은_스태프_계정을_조회하지_않는다() throws Exception {
+        when(request.getServletPath()).thenReturn("/api/v1/users/me");
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + TOKEN);
+        when(jwtProvider.isTokenExpired(TOKEN)).thenReturn(false);
+        when(jwtProvider.validateToken(TOKEN)).thenReturn(true);
+        when(jwtProvider.isAccessToken(TOKEN)).thenReturn(true);
+        when(tokenBlacklistService.isTokenBlacklisted(TOKEN)).thenReturn(false);
+        when(jwtProvider.getRoleFromToken(TOKEN)).thenReturn("USER");
+        when(jwtProvider.getUserIdFromToken(TOKEN)).thenReturn(USER_ID.toString());
+
+        filter.doFilter(request, response, chain);
+
+        verify(staffAccountRepository, never()).existsByUserIdAndRole(USER_ID, StaffRole.ADMIN);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+    }
+}


### PR DESCRIPTION
#87(FOR-123) 리뷰에서 지적한 사항을 반영합니다.

## 1. DB 장애가 운영진 전원 로그아웃으로 번지던 문제

`isActiveStaffAccount` 가 `catch (Exception e) { return false; }` 로 DB 예외를 "계정 없음"으로 해석했습니다. 커넥션 풀 고갈이나 페일오버로 조회가 몇 초 실패하면 전체 운영진 토큰이 401(INVALID_TOKEN)을 받고, 프론트는 이를 세션 만료로 처리해 토큰을 지웁니다.

확인해보니 `doFilterInternal` 바깥에도 `catch (Exception e)` 가 있어서 **예외를 전파하는 것만으로는 부족했습니다.** 거기서 다시 삼켜져 인증 없이 통과하기 때문입니다. `DataAccessException` 을 별도로 잡아 `ServletException` 으로 전파해 500으로 드러나게 했습니다.

조회가 실패한 것과 권한이 없는 것은 다릅니다.

## 2. 멘토 세션이 끊길 시한폭탄

FOR-116 에서 멘토 권한을 `tb_staff_account` 에서 떼어내 `tb_study` 의 멘토 관계로 옮겼는데, 이 검사가 세션 유효성을 다시 계정 존재에 묶고 있었습니다. 지금은 MENTOR 행이 살아 있어 안 깨지지만, 후속 정리로 그 행을 지우는 순간 로그인 중인 멘토가 전부 401 이 됩니다.

검사 대상을 ADMIN 으로 한정했습니다. 원래 목적인 "삭제된 운영진 차단"은 그대로 동작합니다.

## 3. 회장 비밀번호를 아무도 재설정할 수 없던 문제

회장 가드가 `findAndValidateTargetAdmin` 에 있었는데, 이 헬퍼는 `deleteAdmin` 과 `updateAdmin` 이 함께 씁니다. 삭제만 막으려던 것이 수정까지 막아, 회장이 비밀번호를 분실하면 본인은 자기 자신 관리 불가에 걸리고 부회장은 403 이라 DB 직접 수정 외에 방법이 없었습니다.

가드를 `deleteAdmin` 으로 옮겼습니다.

## 4. 부원 삭제가 유지되지 않던 문제

수강 관계만 지우고 지원서의 ACCEPT 를 남겨서 두 가지가 깨졌습니다.

- 어드민이 회비 화면에서 아무 값이나 저장하면 `DuesService.synchronizeStudyMembership` 이 합격 지원서를 근거로 수강생을 되살립니다. 그것도 `certificate_status`/`certificate_url` 이 비어 있는 새 행으로요.
- 멘토가 다시 합격 처리해 복구하려 해도 `UserApplyService:143` 의 중복 스킵에 걸려 `StudyUser` 가 재생성되지 않습니다.

삭제 시 지원서의 합격을 함께 되돌립니다(`UserApply.revertAcceptance`). 이렇게 하면 `acceptedStudyId` 가 비어 회비 동기화가 부활시키지 않고, 멘토의 재합격 경로도 열립니다.

되돌릴 수 없는 삭제이고 운영진 누구나 호출할 수 있으므로 감사 로그도 남깁니다.

## 테스트

`JwtAuthenticationFilterStaffCheckTest` 신규 4케이스 — 삭제된 운영진 차단, DB 장애 전파, MENTOR 미조회, USER 미조회

`UserServiceMemberDeletionTest` — 합격 되돌림 검증과 유저 부재 케이스 추가. `existsById` → `findById` 변경에 맞춰 기존 2케이스 갱신

`compileJava`, `test` 통과. 스키마 변경 없어 배포 선행 SQL 불필요합니다.