### PR TITLE
(web): 스터디 목록에 썸네일 조회 URL을 추가한다

### DIFF
--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -66,7 +66,7 @@ public class StudyService {
 
         if (page != null) {
             List<Study> studies = studyRepository.getStudiesWithOffset(searchCond, page, size);
-            List<StudyDto> dtos = studies.stream().map(StudyDto::from).toList();
+            List<StudyDto> dtos = studies.stream().map(this::toStudyDto).toList();
             boolean hasNext = (long) (page + 1) * size < totalElements;
             return CursorPageResponse.ofOffset(dtos, hasNext, totalElements, page, size);
         }
@@ -74,7 +74,7 @@ public class StudyService {
         List<Study> studies = studyRepository.getStudies(searchCond, cursor, size);
         boolean hasNext = studies.size() > size;
         List<Study> content = hasNext ? studies.subList(0, size) : studies;
-        List<StudyDto> dtos = content.stream().map(StudyDto::from).toList();
+        List<StudyDto> dtos = content.stream().map(this::toStudyDto).toList();
         Integer nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
         return CursorPageResponse.ofCursor(dtos, nextCursor, hasNext, totalElements);
     }
@@ -84,7 +84,7 @@ public class StudyService {
 
         return studyRepository.findStudiesByMentorId(mentorId)
             .stream()
-            .map(StudyDto::from)
+            .map(this::toStudyDto)
             .toList();
     }
 
@@ -409,6 +409,20 @@ public class StudyService {
     private FileInfo uploadAndBuildFileInfo(MultipartFile file) {
         String objectKey = filePort.uploadFile(file);
         return filePort.generatePresignedViewUrl(objectKey);
+    }
+
+    private StudyDto toStudyDto(Study study) {
+        String thumbnailImage = study.getThumbnailImage();
+        if (thumbnailImage == null || thumbnailImage.isBlank()) {
+            return StudyDto.from(study);
+        }
+
+        return StudyDto.from(
+                study,
+                thumbnailImage.startsWith("http://") || thumbnailImage.startsWith("https://")
+                        ? thumbnailImage
+                        : filePort.generatePresignedViewUrl(thumbnailImage).presignedUrl()
+        );
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/study/dto/StudyDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyDto.java
@@ -29,8 +29,13 @@ public class StudyDto {
     private final String location;
     private final StudyDifficulty difficulty;
     private final String imgUrl;
+    private final String thumbnailImage;
 
     public static StudyDto from(Study studyEntity) {
+        return from(studyEntity, null);
+    }
+
+    public static StudyDto from(Study studyEntity, String thumbnailImage) {
         return StudyDto.builder()
                 .id(studyEntity.getId())
                 .actYear(studyEntity.getActYear())
@@ -48,6 +53,7 @@ public class StudyDto {
                 .location(studyEntity.getLocation())
                 .difficulty(studyEntity.getDifficulty())
                 .imgUrl(studyEntity.getImgUrl())
+                .thumbnailImage(thumbnailImage)
                 .build();
     }
 }

--- a/src/main/java/org/forif_backend/web/study/dto/StudyResponse.java
+++ b/src/main/java/org/forif_backend/web/study/dto/StudyResponse.java
@@ -20,6 +20,7 @@ public record StudyResponse(
         String location,
         String difficulty,
         String imgUrl,
+        String thumbnailImage,
         Integer actYear,
         Integer actSemester
 ) {
@@ -51,6 +52,7 @@ public record StudyResponse(
                 study.getLocation(),
                 difficultyValue,
                 study.getImgUrl(),
+                study.getThumbnailImage(),
                 study.getActYear(),
                 study.getActSemester()
         );


### PR DESCRIPTION
- 스터디 목록 및 내가 개설한 스터디 조회 시 썸네일 파일 키를 조회 URL로 변환
- 목록 응답에 thumbnailImage 필드 추가
- 내부 파일 키가 응답에 그대로 노출되지 않도록 처리