### PR TITLE
Feature/for 127

### DIFF
--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -122,7 +122,7 @@ public class StudyService {
                                             .semester(semester)
                                             .semesterLabel(year + "-" + semester)
                                             .isCurrent(year == currentYear && semester == currentSemester)
-                                            .study(StudyInfo.from(firstStudy,
+                                            .study(toStudyInfo(firstStudy,
                                                     certificateIssuedMap.getOrDefault(firstStudy.getId(), false)))  // 첫 번째 스터디만 (한 학기에 1개)
                                             .build();
                                 }
@@ -422,6 +422,21 @@ public class StudyService {
                         ? thumbnailImage
                         : filePort.generatePresignedViewUrl(thumbnailImage).presignedUrl()
         );
+    }
+
+    private StudyInfo toStudyInfo(Study study, boolean certificateIssued) {
+        return StudyInfo.from(study, certificateIssued, resolveThumbnailImage(study));
+    }
+
+    private String resolveThumbnailImage(Study study) {
+        String thumbnailImage = study.getThumbnailImage();
+        if (thumbnailImage == null || thumbnailImage.isBlank()) {
+            return null;
+        }
+        if (thumbnailImage.startsWith("http://") || thumbnailImage.startsWith("https://")) {
+            return thumbnailImage;
+        }
+        return filePort.generatePresignedViewUrl(thumbnailImage).presignedUrl();
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/study/dto/StudyInfo.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyInfo.java
@@ -21,6 +21,7 @@ public record StudyInfo(
         String location,
         Integer difficulty,
         String imgUrl,
+        String thumbnailImage,
         boolean certificateIssued
 ) {
     /**
@@ -31,6 +32,10 @@ public record StudyInfo(
     }
 
     public static StudyInfo from(Study study, boolean certificateIssued) {
+        return from(study, certificateIssued, null);
+    }
+
+    public static StudyInfo from(Study study, boolean certificateIssued, String thumbnailImage) {
         // tags 리스트를 태그 이름 리스트로 변환
         List<String> tagNames = study.getTags() != null
                 ? study.getTags().stream()
@@ -51,6 +56,7 @@ public record StudyInfo(
                 .location(study.getLocation())
                 .difficulty(study.getDifficulty() != null ? study.getDifficulty().getLevel() : null)
                 .imgUrl(study.getImgUrl())
+                .thumbnailImage(thumbnailImage)
                 .certificateIssued(certificateIssued)
                 .build();
     }

--- a/src/main/java/org/forif_backend/application/user/UserApplyService.java
+++ b/src/main/java/org/forif_backend/application/user/UserApplyService.java
@@ -118,7 +118,7 @@ public class UserApplyService {
     }
 
     /**
-     * 본인의 대기 중인 스터디 신청서를 취소합니다.
+     * 본인의 활동 학기 대기 중 스터디 신청서를 취소합니다.
      * 신청서 행을 삭제하므로, 1·2순위가 모두 대기 상태일 때만 허용합니다.
      */
     @Transactional
@@ -131,6 +131,8 @@ public class UserApplyService {
             throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
         }
 
+        requireActiveSemesterApplication(apply);
+
         boolean hasReviewedPrimary = apply.getPrimaryStatus() != UserApplyStatus.PENDING;
         boolean hasReviewedSecondary = apply.getSecondaryStatus() != null
                 && apply.getSecondaryStatus() != UserApplyStatus.PENDING;
@@ -142,11 +144,12 @@ public class UserApplyService {
     }
 
     private UserApply getApplication(Long applyId) {
-        UserApply apply = userRepository.findUserApplyById(applyId);
-        if (apply == null) {
-            throw new ForifException(ErrorCode.STUDY_APPLY_NOT_FOUND);
-        }
-        return apply;
+        return findApplication(applyId)
+                .orElseThrow(() -> new ForifException(ErrorCode.STUDY_APPLY_NOT_FOUND));
+    }
+
+    private Optional<UserApply> findApplication(Long applyId) {
+        return Optional.ofNullable(userRepository.findUserApplyById(applyId));
     }
 
     /**
@@ -162,7 +165,11 @@ public class UserApplyService {
         Study study = getStudyIfActiveMentor(userId, studyId);
 
         for (Long applyId : applyIds) {
-            UserApply apply = userRepository.findUserApplyById(applyId);
+            Optional<UserApply> applyOpt = findApplication(applyId);
+            if (applyOpt.isEmpty()) {
+                continue;
+            }
+            UserApply apply = applyOpt.get();
 
             boolean isPrimary = apply.getPrimaryStudy() == studyId;
             boolean isSecondary = studyId.equals(apply.getSecondaryStudy());
@@ -210,7 +217,11 @@ public class UserApplyService {
         getStudyIfActiveMentor(userId, studyId);
 
         for (Long applyId : applyIds) {
-            UserApply apply = userRepository.findUserApplyById(applyId);
+            Optional<UserApply> applyOpt = findApplication(applyId);
+            if (applyOpt.isEmpty()) {
+                continue;
+            }
+            UserApply apply = applyOpt.get();
 
             boolean isPrimary = apply.getPrimaryStudy() == studyId;
             boolean isSecondary = studyId.equals(apply.getSecondaryStudy());
@@ -290,7 +301,7 @@ public class UserApplyService {
      */
     public ApplyDetailInfo getApplyDetailInfo(Long userId, Integer studyId, Long applyId) {
         Study study = getStudyIfMentor(userId, studyId);
-        UserApply userApply = userRepository.findUserApplyById(applyId);
+        UserApply userApply = getApplication(applyId);
 
         // 신청서가 해당 스터디에 대한 것인지 검증
         if (userApply.getPrimaryStudy() != study.getId() && !study.getId().equals(userApply.getSecondaryStudy())) {
@@ -311,7 +322,7 @@ public class UserApplyService {
         semesterPhaseGuard.requireOpen(SemesterPhase.MENTEE_REVIEW);
 
         Study study = getStudyIfActiveMentor(userId, studyId);
-        UserApply userApply = userRepository.findUserApplyById(applyId);
+        UserApply userApply = getApplication(applyId);
 
         // 신청서가 해당 스터디에 대한 것인지 검증
         if (userApply.getPrimaryStudy() != study.getId() && !study.getId().equals(userApply.getSecondaryStudy())) {
@@ -342,6 +353,13 @@ public class UserApplyService {
 
         studyMentorAccess.requireMentorOfActiveSemester(study, userId);
         return study;
+    }
+
+    private void requireActiveSemesterApplication(UserApply apply) {
+        SemesterInfo active = semesterService.getActive();
+        if (apply.getApplyYear() != active.actYear() || apply.getApplySemester() != active.actSemester()) {
+            throw new ForifException(ErrorCode.STUDY_APPLY_NOT_IN_ACTIVE_SEMESTER);
+        }
     }
 
     private String getApplicationContentForStudy(UserApply userApply, Integer studyId) {

--- a/src/main/java/org/forif_backend/application/user/UserApplyService.java
+++ b/src/main/java/org/forif_backend/application/user/UserApplyService.java
@@ -96,7 +96,7 @@ public class UserApplyService {
     public void updateApplication(Long userId, Long applyId, UserApplyUpdateRequest request) {
         semesterPhaseGuard.requireOpen(SemesterPhase.MENTEE_RECRUIT);
 
-        UserApply apply = userRepository.findUserApplyById(applyId);
+        UserApply apply = getApplication(applyId);
 
         if (!apply.getApplier().getId().equals(userId)) {
             throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
@@ -115,6 +115,38 @@ public class UserApplyService {
         } else {
             throw new ForifException(ErrorCode.INVALID_INPUT);
         }
+    }
+
+    /**
+     * 본인의 대기 중인 스터디 신청서를 취소합니다.
+     * 신청서 행을 삭제하므로, 1·2순위가 모두 대기 상태일 때만 허용합니다.
+     */
+    @Transactional
+    public void cancelApplication(Long userId, Long applyId) {
+        semesterPhaseGuard.requireOpen(SemesterPhase.MENTEE_RECRUIT);
+
+        UserApply apply = getApplication(applyId);
+
+        if (!apply.getApplier().getId().equals(userId)) {
+            throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
+        }
+
+        boolean hasReviewedPrimary = apply.getPrimaryStatus() != UserApplyStatus.PENDING;
+        boolean hasReviewedSecondary = apply.getSecondaryStatus() != null
+                && apply.getSecondaryStatus() != UserApplyStatus.PENDING;
+        if (hasReviewedPrimary || hasReviewedSecondary) {
+            throw new ForifException(ErrorCode.APPLY_NOT_PENDING);
+        }
+
+        userRepository.deleteUserApply(apply);
+    }
+
+    private UserApply getApplication(Long applyId) {
+        UserApply apply = userRepository.findUserApplyById(applyId);
+        if (apply == null) {
+            throw new ForifException(ErrorCode.STUDY_APPLY_NOT_FOUND);
+        }
+        return apply;
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/user/UserService.java
+++ b/src/main/java/org/forif_backend/application/user/UserService.java
@@ -273,12 +273,24 @@ public class UserService {
                 study.getEndTime(),
                 study.getLocation(),
                 study.getDifficulty() != null ? study.getDifficulty().ordinal() : null,
-                study.getImgUrl()
+                study.getImgUrl(),
+                resolveThumbnailImage(study)
         );
 
         Integer statusValue = status != null ? status.ordinal() : null;
 
         return new ApplicationDetailDto(priority, studyInfo, statusValue, intro);
+    }
+
+    private String resolveThumbnailImage(Study study) {
+        String thumbnailImage = study.getThumbnailImage();
+        if (thumbnailImage == null || thumbnailImage.isBlank()) {
+            return null;
+        }
+        if (thumbnailImage.startsWith("http://") || thumbnailImage.startsWith("https://")) {
+            return thumbnailImage;
+        }
+        return filePort.generatePresignedViewUrl(thumbnailImage).presignedUrl();
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/user/dto/StudyInfoDto.java
+++ b/src/main/java/org/forif_backend/application/user/dto/StudyInfoDto.java
@@ -17,6 +17,7 @@ public record StudyInfoDto(
         String endTime,
         String location,
         Integer difficulty,
-        String imgUrl
+        String imgUrl,
+        String thumbnailImage
 ) {
 }

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "FOR020-403", "권한이 없습니다."),
     NOT_STUDY_MENTOR(HttpStatus.FORBIDDEN, "FOR021-403", "해당 스터디의 멘토가 아닙니다."),
     STUDY_NOT_IN_ACTIVE_SEMESTER(HttpStatus.FORBIDDEN, "FOR127-403", "지난 학기 스터디는 관리할 수 없습니다."),
+    STUDY_APPLY_NOT_IN_ACTIVE_SEMESTER(HttpStatus.FORBIDDEN, "FOR129-403", "활동 학기가 아닌 스터디 신청은 취소할 수 없습니다."),
     HACKATHON_PARTICIPATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "FOR064-403", "해커톤 참가 자격이 없습니다."),
     HACKATHON_TEAM_LEADER_REQUIRED(HttpStatus.FORBIDDEN, "FOR065-403", "해커톤 팀장 권한이 필요합니다."),
     HACKATHON_EVALUATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "FOR066-403", "해커톤 평가 권한이 없습니다."),

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     ALREADY_APPLIED_SECONDARY(HttpStatus.BAD_REQUEST, "FOR011-400", "이미 2순위 스터디에 지원했습니다."),
     PRIMARY_NOT_APPLIED(HttpStatus.BAD_REQUEST, "FOR037-400", "1순위 스터디에 먼저 지원해야 합니다."),
     REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "FOR012-400", "거절 사유는 필수입니다."),
-    APPLY_NOT_PENDING(HttpStatus.BAD_REQUEST, "FOR038-400", "대기중(PENDING) 상태의 신청서만 수정할 수 있습니다."),
+    APPLY_NOT_PENDING(HttpStatus.BAD_REQUEST, "FOR038-400", "대기중(PENDING) 상태의 신청서만 수정하거나 취소할 수 있습니다."),
     CERTIFICATE_SIGNATURE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FOR039-400", "현재 회장의 서명이 등록되지 않았습니다. 인증서 발급 페이지에서 서명을 먼저 등록해주세요."),
     REAPPLY_ONLY_FOR_REJECTED(HttpStatus.BAD_REQUEST, "FOR013-400", "재요청은 거절된 신청서에만 가능합니다."),
     INVALID_FILE_ATTACHMENT(HttpStatus.BAD_REQUEST, "FOR014-400", "파일 첨부가 잘못됐습니다."),

--- a/src/main/java/org/forif_backend/domain/user/UserRepository.java
+++ b/src/main/java/org/forif_backend/domain/user/UserRepository.java
@@ -25,6 +25,8 @@ public interface UserRepository {
 
     void createUserApply(UserApply userApply);
 
+    void deleteUserApply(UserApply userApply);
+
     boolean existUserApply(int year, int semester, User applier);
 
     Optional<UserApply> findUserApplyByYearAndSemesterAndUser(int year, int semester, User user);

--- a/src/main/java/org/forif_backend/infrastructure/persistence/user/UserApplyJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/user/UserApplyJpaRepository.java
@@ -16,15 +16,19 @@ public interface UserApplyJpaRepository extends JpaRepository<UserApply, Long> {
     List<UserApply> findByApplierId(Long applierId);
 
     @Query("""
-            SELECT DISTINCT ua.applier FROM UserApply ua
-            WHERE ua.applyYear = :year
-              AND ua.applySemester = :semester
+            SELECT u FROM User u
+            WHERE EXISTS (
+                SELECT 1 FROM UserApply ua
+                WHERE ua.applier = u
+                  AND ua.applyYear = :year
+                  AND ua.applySemester = :semester
+            )
               AND (
                   :search IS NULL OR :search = ''
-                  OR LOWER(ua.applier.userName) LIKE LOWER(CONCAT('%', :search, '%'))
-                  OR LOWER(ua.applier.department) LIKE LOWER(CONCAT('%', :search, '%'))
+                  OR LOWER(u.userName) LIKE LOWER(CONCAT('%', :search, '%'))
+                  OR LOWER(u.department) LIKE LOWER(CONCAT('%', :search, '%'))
               )
-            ORDER BY ua.applier.userName ASC, ua.applier.id ASC
+            ORDER BY u.userName ASC, u.id ASC
             """)
     List<User> findApplicantsByYearSemester(@Param("year") int year,
                                             @Param("semester") int semester,

--- a/src/main/java/org/forif_backend/infrastructure/persistence/user/UserRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/user/UserRepositoryImpl.java
@@ -62,6 +62,11 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public void deleteUserApply(UserApply userApply) {
+        userApplyJpaRepository.delete(userApply);
+    }
+
+    @Override
     public boolean existUserApply(int year, int semester, User applier) {
         Integer isExist = queryFactory.selectOne()
                 .from(userApply)

--- a/src/main/java/org/forif_backend/web/user/UserDtoMapper.java
+++ b/src/main/java/org/forif_backend/web/user/UserDtoMapper.java
@@ -88,6 +88,7 @@ public class UserDtoMapper {
                 .location(info.location())
                 .difficulty(info.difficulty())
                 .imgUrl(info.imgUrl())
+                .thumbnailImage(info.thumbnailImage())
                 .certificateIssued(info.certificateIssued())
                 .build();
     }

--- a/src/main/java/org/forif_backend/web/user/dto/UserStudiesResponse.java
+++ b/src/main/java/org/forif_backend/web/user/dto/UserStudiesResponse.java
@@ -32,6 +32,7 @@ public record UserStudiesResponse(
             String location,
             Integer difficulty,
             String imgUrl,
+            String thumbnailImage,
             boolean certificateIssued
     ) {
     }

--- a/src/main/java/org/forif_backend/web/userApply/UserApplyController.java
+++ b/src/main/java/org/forif_backend/web/userApply/UserApplyController.java
@@ -51,6 +51,16 @@ public class UserApplyController {
         return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
     }
 
+    @Operation(summary = "수강 신청 취소", description = "본인의 대기 중인 스터디 수강 신청서를 취소합니다.")
+    @DeleteMapping("/{applyId}")
+    public ResponseEntity<ApiResponse<Void>> cancelApplication(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "신청서 ID") @PathVariable("applyId") Long applyId
+    ) {
+        userApplyService.cancelApplication(userId, applyId);
+        return ResponseEntity.ok(ApiResponse.successWithMsg("Success"));
+    }
+
     @Operation(summary = "신청자 목록 조회 (멘토 전용)", description = "해당 스터디에 신청한 멘티 목록을 조회합니다. 상태 필터 및 날짜 정렬을 지원합니다.")
     @GetMapping("/{studyId}")
     public ResponseEntity<ApiResponse<PageResponse<UserApplyResponse>>> getUserApply(

--- a/src/test/java/org/forif_backend/application/user/UserApplyServiceCancelTest.java
+++ b/src/test/java/org/forif_backend/application/user/UserApplyServiceCancelTest.java
@@ -1,0 +1,148 @@
+package org.forif_backend.application.user;
+
+import org.forif_backend.application.dues.DuesService;
+import org.forif_backend.application.semester.SemesterPhaseGuard;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.study.StudyMentorAccess;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.semester.SemesterPhase;
+import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.StudyUserRepository;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserApply;
+import org.forif_backend.domain.user.UserApplyStatus;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserApplyServiceCancelTest {
+
+    private static final long APPLICATION_ID = 100L;
+    private static final long APPLICANT_ID = 1L;
+
+    @Mock
+    private SemesterService semesterService;
+    @Mock
+    private SemesterPhaseGuard semesterPhaseGuard;
+    @Mock
+    private StudyMentorAccess studyMentorAccess;
+    @Mock
+    private DuesService duesService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private StudyRepository studyRepository;
+    @Mock
+    private StudyUserRepository studyUserRepository;
+
+    @InjectMocks
+    private UserApplyService userApplyService;
+
+    @Test
+    void deletesOwnApplicationWhenAllPrioritiesArePending() {
+        UserApply application = pendingApplication(applicant());
+        application.addSecondaryStudy(20, "2순위 스터디", "2순위 지원 동기");
+        when(userRepository.findUserApplyById(APPLICATION_ID)).thenReturn(application);
+
+        userApplyService.cancelApplication(APPLICANT_ID, APPLICATION_ID);
+
+        verify(semesterPhaseGuard).requireOpen(SemesterPhase.MENTEE_RECRUIT);
+        verify(userRepository).deleteUserApply(application);
+    }
+
+    @Test
+    void doesNotDeleteAnotherUsersApplication() {
+        UserApply application = pendingApplication(user(2L));
+        when(userRepository.findUserApplyById(APPLICATION_ID)).thenReturn(application);
+
+        assertError(ErrorCode.INSUFFICIENT_PERMISSION,
+                () -> userApplyService.cancelApplication(APPLICANT_ID, APPLICATION_ID));
+
+        verify(userRepository, never()).deleteUserApply(application);
+    }
+
+    @Test
+    void doesNotDeleteApplicationWhenPrimaryHasBeenReviewed() {
+        UserApply application = pendingApplication(applicant());
+        application.updateStatus(10, UserApplyStatus.ACCEPT);
+        when(userRepository.findUserApplyById(APPLICATION_ID)).thenReturn(application);
+
+        assertError(ErrorCode.APPLY_NOT_PENDING,
+                () -> userApplyService.cancelApplication(APPLICANT_ID, APPLICATION_ID));
+
+        verify(userRepository, never()).deleteUserApply(application);
+    }
+
+    @Test
+    void doesNotDeleteApplicationWhenSecondaryHasBeenReviewed() {
+        UserApply application = pendingApplication(applicant());
+        application.addSecondaryStudy(20, "2순위 스터디", "2순위 지원 동기");
+        application.updateStatus(20, UserApplyStatus.REJECT);
+        when(userRepository.findUserApplyById(APPLICATION_ID)).thenReturn(application);
+
+        assertError(ErrorCode.APPLY_NOT_PENDING,
+                () -> userApplyService.cancelApplication(APPLICANT_ID, APPLICATION_ID));
+
+        verify(userRepository, never()).deleteUserApply(application);
+    }
+
+    @Test
+    void returnsNotFoundWhenApplicationDoesNotExist() {
+        when(userRepository.findUserApplyById(APPLICATION_ID)).thenReturn(null);
+
+        assertError(ErrorCode.STUDY_APPLY_NOT_FOUND,
+                () -> userApplyService.cancelApplication(APPLICANT_ID, APPLICATION_ID));
+
+        verify(userRepository, never()).deleteUserApply(any());
+    }
+
+    @Test
+    void doesNotLookUpOrDeleteApplicationWhenRecruitmentIsClosed() {
+        doThrow(new ForifException(ErrorCode.SEMESTER_PHASE_CLOSED))
+                .when(semesterPhaseGuard)
+                .requireOpen(SemesterPhase.MENTEE_RECRUIT);
+
+        assertError(ErrorCode.SEMESTER_PHASE_CLOSED,
+                () -> userApplyService.cancelApplication(APPLICANT_ID, APPLICATION_ID));
+
+        verify(userRepository, never()).findUserApplyById(APPLICATION_ID);
+        verify(userRepository, never()).deleteUserApply(any());
+    }
+
+    private User applicant() {
+        return user(APPLICANT_ID);
+    }
+
+    private User user(Long id) {
+        return User.createUser(id, "신청자", "applicant@forif.org", "01012345678", "컴퓨터학부");
+    }
+
+    private UserApply pendingApplication(User applicant) {
+        Study study = mock(Study.class);
+        when(study.getId()).thenReturn(10);
+        when(study.getStudyName()).thenReturn("1순위 스터디");
+        return UserApply.applyStudy(applicant, study, "지원 동기", 2026, 1);
+    }
+
+    private void assertError(ErrorCode expectedErrorCode, Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(expectedErrorCode));
+    }
+}

--- a/src/test/java/org/forif_backend/application/user/UserApplyServiceCancelTest.java
+++ b/src/test/java/org/forif_backend/application/user/UserApplyServiceCancelTest.java
@@ -3,6 +3,7 @@ package org.forif_backend.application.user;
 import org.forif_backend.application.dues.DuesService;
 import org.forif_backend.application.semester.SemesterPhaseGuard;
 import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.application.study.StudyMentorAccess;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
@@ -14,6 +15,7 @@ import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.UserApply;
 import org.forif_backend.domain.user.UserApplyStatus;
 import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -52,6 +55,11 @@ class UserApplyServiceCancelTest {
 
     @InjectMocks
     private UserApplyService userApplyService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 1));
+    }
 
     @Test
     void deletesOwnApplicationWhenAllPrioritiesArePending() {
@@ -102,6 +110,17 @@ class UserApplyServiceCancelTest {
     }
 
     @Test
+    void doesNotDeleteApplicationFromAnotherSemester() {
+        UserApply application = pendingApplication(applicant(), 2025, 2);
+        when(userRepository.findUserApplyById(APPLICATION_ID)).thenReturn(application);
+
+        assertError(ErrorCode.STUDY_APPLY_NOT_IN_ACTIVE_SEMESTER,
+                () -> userApplyService.cancelApplication(APPLICANT_ID, APPLICATION_ID));
+
+        verify(userRepository, never()).deleteUserApply(application);
+    }
+
+    @Test
     void returnsNotFoundWhenApplicationDoesNotExist() {
         when(userRepository.findUserApplyById(APPLICATION_ID)).thenReturn(null);
 
@@ -133,10 +152,14 @@ class UserApplyServiceCancelTest {
     }
 
     private UserApply pendingApplication(User applicant) {
+        return pendingApplication(applicant, 2026, 1);
+    }
+
+    private UserApply pendingApplication(User applicant, int year, int semester) {
         Study study = mock(Study.class);
         when(study.getId()).thenReturn(10);
         when(study.getStudyName()).thenReturn("1순위 스터디");
-        return UserApply.applyStudy(applicant, study, "지원 동기", 2026, 1);
+        return UserApply.applyStudy(applicant, study, "지원 동기", year, semester);
     }
 
     private void assertError(ErrorCode expectedErrorCode, Runnable action) {

--- a/src/test/java/org/forif_backend/application/user/UserApplyServiceDeletedApplicationTest.java
+++ b/src/test/java/org/forif_backend/application/user/UserApplyServiceDeletedApplicationTest.java
@@ -4,12 +4,16 @@ import org.forif_backend.application.dues.DuesService;
 import org.forif_backend.application.semester.SemesterPhaseGuard;
 import org.forif_backend.application.semester.SemesterService;
 import org.forif_backend.application.study.StudyMentorAccess;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.domain.study.Study;
 import org.forif_backend.domain.study.StudyRepository;
 import org.forif_backend.domain.study.StudyUserRepository;
 import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.UserApply;
+import org.forif_backend.domain.user.UserApplyStatus;
 import org.forif_backend.domain.user.UserRepository;
+import org.forif_backend.web.userApply.dto.UserApplyStatusUpdateRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,13 +23,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class UserApplyServiceAcceptanceTest {
+class UserApplyServiceDeletedApplicationTest {
 
     @Mock
     private SemesterService semesterService;
@@ -46,39 +51,43 @@ class UserApplyServiceAcceptanceTest {
     private UserApplyService userApplyService;
 
     @Test
-    void acceptsApplicationWithoutDirectlyCreatingStudyUser() {
+    void skipsDeletedApplicationAndRejectsRemainingApplications() {
         Study study = mock(Study.class);
-        User applicant = User.createUser(1L, "신청자", "applicant@hanyang.ac.kr", "01011112222", "컴퓨터학부");
-        UserApply application = mock(UserApply.class);
-
-        when(studyRepository.findStudyById(10)).thenReturn(Optional.of(study));
-        when(userRepository.findUserApplyById(100L)).thenReturn(application);
-        when(application.getPrimaryStudy()).thenReturn(10);
-        when(application.getApplier()).thenReturn(applicant);
-
-        userApplyService.acceptApplications(99L, 10, List.of(100L));
-
-        verify(application).updateStatus(10, org.forif_backend.domain.user.UserApplyStatus.ACCEPT);
-        verify(duesService).ensureMemberCheck(study, applicant);
-        verify(duesService).registerStudyUserIfEligible(study, applicant);
-        verify(studyUserRepository, never()).save(org.mockito.ArgumentMatchers.any());
-    }
-
-    @Test
-    void skipsDeletedApplicationAndAcceptsRemainingApplications() {
-        Study study = mock(Study.class);
-        User applicant = User.createUser(1L, "신청자", "applicant@hanyang.ac.kr", "01011112222", "컴퓨터학부");
         UserApply remainingApplication = mock(UserApply.class);
 
         when(studyRepository.findStudyById(10)).thenReturn(Optional.of(study));
         when(userRepository.findUserApplyById(100L)).thenReturn(null);
         when(userRepository.findUserApplyById(101L)).thenReturn(remainingApplication);
         when(remainingApplication.getPrimaryStudy()).thenReturn(10);
-        when(remainingApplication.getApplier()).thenReturn(applicant);
 
-        userApplyService.acceptApplications(99L, 10, List.of(100L, 101L));
+        userApplyService.rejectApplications(99L, 10, List.of(100L, 101L));
 
-        verify(remainingApplication).updateStatus(10, org.forif_backend.domain.user.UserApplyStatus.ACCEPT);
-        verify(duesService).registerStudyUserIfEligible(study, applicant);
+        verify(remainingApplication).updateStatus(10, UserApplyStatus.REJECT);
+    }
+
+    @Test
+    void returnsNotFoundWhenMentorViewsDeletedApplication() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyById(10)).thenReturn(Optional.of(study));
+        when(userRepository.findUserApplyById(100L)).thenReturn(null);
+
+        assertError(() -> userApplyService.getApplyDetailInfo(99L, 10, 100L));
+    }
+
+    @Test
+    void returnsNotFoundWhenMentorUpdatesDeletedApplication() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyById(10)).thenReturn(Optional.of(study));
+        when(userRepository.findUserApplyById(100L)).thenReturn(null);
+
+        assertError(() -> userApplyService.updateApplyStatus(
+                99L, 10, 100L, new UserApplyStatusUpdateRequest(UserApplyStatus.REJECT)));
+    }
+
+    private void assertError(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.STUDY_APPLY_NOT_FOUND));
     }
 }


### PR DESCRIPTION
feat: 스터디 신청 취소 API 추가

- 대기 중인 본인 스터디 신청서를 삭제하는 DELETE API 추가
- 1·2순위 중 검토가 완료된 신청서는 취소 제한
- 존재하지 않는 신청서는 404로 처리
- 신청서 수정·취소의 조회 예외 처리 일관화
- 취소 서비스 테스트 추가


fix: 회비 관리 신청자 조회 MySQL DISTINCT 정렬 오류 수정

- 신청자 조회를 DISTINCT JOIN에서 EXISTS 기반 조회로 변경
- MySQL의 DISTINCT ORDER BY 호환성 오류 해결