### PR TITLE
Feature/for 128

### DIFF
--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -213,9 +213,8 @@ public class StudyService {
         }
 
         // 태그 교체
-        if (request.getStudyTagIds() != null) {
-            List<StudyTag> tags = studyRepository.findAllStudyTagById(request.getStudyTagIds());
-            study.setTags(tags);
+        if (request.getStudyTagIds() != null || request.getStudyTagNames() != null) {
+            study.setTags(resolveStudyTags(request.getStudyTagIds(), request.getStudyTagNames()));
         }
 
         // 커리큘럼: 기존 삭제 후 재생성
@@ -270,13 +269,47 @@ public class StudyService {
         SemesterInfo semester = semesterService.getActive();
         Study study = Study.createPendingStudy(mentor, semester.actYear(), semester.actSemester());
 
-        List<StudyTag> tags = studyRepository.findAllStudyTagById(request.getStudyTagId());
+        List<StudyTag> tags = resolveStudyTags(request);
         User secondaryMentor = resolveSecondaryMentor(mentorId, request.getSecondaryMentorId());
 
         // 공통 데이터 반영
         study.applyRequestData(request, tags, secondaryMentor);
 
         return saveStudyWithResources(study, request, thumbnail, referenceFiles);
+    }
+
+    private List<StudyTag> resolveStudyTags(CreateStudyApplyRequest request) {
+        return resolveStudyTags(request.getStudyTagId(), request.getStudyTagNames());
+    }
+
+    private List<StudyTag> resolveStudyTags(List<Long> tagIds, List<String> tagNames) {
+        List<StudyTag> tags;
+        int requestedTagCount;
+
+        if (tagNames != null && !tagNames.isEmpty()) {
+            List<String> normalizedTagNames = tagNames.stream()
+                    .map(String::trim)
+                    .distinct()
+                    .toList();
+            tags = studyRepository.findAllStudyTagByName(normalizedTagNames);
+            requestedTagCount = normalizedTagNames.size();
+        } else {
+            if (tagIds == null || tagIds.isEmpty()) {
+                throw new ForifException(ErrorCode.INVALID_INPUT);
+            }
+
+            List<Long> distinctTagIds = tagIds.stream()
+                    .distinct()
+                    .toList();
+            tags = studyRepository.findAllStudyTagById(distinctTagIds);
+            requestedTagCount = distinctTagIds.size();
+        }
+
+        if (tags.size() != requestedTagCount) {
+            throw new ForifException(ErrorCode.INVALID_INPUT);
+        }
+
+        return tags;
     }
 
     private User resolveSecondaryMentor(Long primaryMentorId, Long secondaryMentorId) {
@@ -350,7 +383,7 @@ public class StudyService {
         study.reApply(); // 내부에서 상태값을 변경하는 로직
 
         // 3. 기본 데이터 업데이트 (스터디명, 설명, 태그 등)
-        List<StudyTag> tags = studyRepository.findAllStudyTagById(request.getStudyTagId());
+        List<StudyTag> tags = resolveStudyTags(request);
         User secondaryMentor = resolveSecondaryMentor(study.getPrimaryMentor().getId(), request.getSecondaryMentorId());
         study.applyRequestData(request, tags, secondaryMentor);
 

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -283,33 +283,38 @@ public class StudyService {
     }
 
     private List<StudyTag> resolveStudyTags(List<Long> tagIds, List<String> tagNames) {
-        List<StudyTag> tags;
-        int requestedTagCount;
-
         if (tagNames != null && !tagNames.isEmpty()) {
             List<String> normalizedTagNames = tagNames.stream()
-                    .map(String::trim)
+                    .map(StudyService::normalizeTagName)
                     .distinct()
                     .toList();
-            tags = studyRepository.findAllStudyTagByName(normalizedTagNames);
-            requestedTagCount = normalizedTagNames.size();
-        } else {
-            if (tagIds == null || tagIds.isEmpty()) {
+            List<StudyTag> tags = studyRepository.findAllStudyTagByName(normalizedTagNames);
+            if (tags.size() != normalizedTagNames.size()) {
                 throw new ForifException(ErrorCode.INVALID_INPUT);
             }
+            return tags;
+        }
 
+        if (tagIds != null && !tagIds.isEmpty()) {
             List<Long> distinctTagIds = tagIds.stream()
                     .distinct()
                     .toList();
-            tags = studyRepository.findAllStudyTagById(distinctTagIds);
-            requestedTagCount = distinctTagIds.size();
+            List<StudyTag> tags = studyRepository.findAllStudyTagById(distinctTagIds);
+            if (tags.size() != distinctTagIds.size()) {
+                throw new ForifException(ErrorCode.INVALID_INPUT);
+            }
+            return tags;
         }
 
-        if (tags.size() != requestedTagCount) {
+        // 수정 요청에서 명시적으로 빈 목록을 보내면 기존 태그를 모두 해제한다.
+        return List.of();
+    }
+
+    private static String normalizeTagName(String tagName) {
+        if (tagName == null || tagName.isBlank()) {
             throw new ForifException(ErrorCode.INVALID_INPUT);
         }
-
-        return tags;
+        return tagName.strip().toLowerCase(Locale.ROOT);
     }
 
     private User resolveSecondaryMentor(Long primaryMentorId, Long secondaryMentorId) {

--- a/src/main/java/org/forif_backend/application/study/dto/StudyDetailDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyDetailDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.domain.study.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -34,6 +35,7 @@ public class StudyDetailDto {
     private final String selectionCriteria;
     private final Integer capacity;
     private final Boolean requiresInterview;
+    private final LocalDateTime interviewDate;
     private final List<StudyPlanDto> plans;
     private final List<StudyReferenceDto> references;
     private final List<MentorStudyDto> mentors;
@@ -65,6 +67,7 @@ public class StudyDetailDto {
                 .selectionCriteria(study.getSelectionCriteria())
                 .capacity(study.getCapacity())
                 .requiresInterview(study.getRequiresInterview())
+                .interviewDate(study.getInterviewDate())
                 .plans(plans.stream().map(StudyPlanDto::from).toList())
                 .references(references.stream().map(StudyReferenceDto::from).toList())
                 .mentors(mentorStudies.stream().map(MentorStudyDto::from).toList())

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 public interface StudyRepository {
     Optional<Study> findStudyById(Integer studyId);
     List<StudyTag> findAllStudyTagById(List<Long> tagIds);
+    List<StudyTag> findAllStudyTagByName(List<String> tagNames);
     List<Study> getStudies(StudySearchCond cond, Integer cursor, int size);
     List<Study> getStudiesWithOffset(StudySearchCond cond, int page, int size);
     long countStudiesForUser(StudySearchCond cond);

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -48,6 +48,11 @@ public class StudyRepositoryImpl implements StudyRepository {
     }
 
     @Override
+    public List<StudyTag> findAllStudyTagByName(List<String> tagNames) {
+        return studyTagJpaRepository.findByNameIn(tagNames);
+    }
+
+    @Override
     public List<Study> findStudiesByUserId(Long userId) {
         return studyQueryRepository.findStudiesByUserId(userId);
     }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -49,7 +49,7 @@ public class StudyRepositoryImpl implements StudyRepository {
 
     @Override
     public List<StudyTag> findAllStudyTagByName(List<String> tagNames) {
-        return studyTagJpaRepository.findByNameIn(tagNames);
+        return studyTagJpaRepository.findByNameInIgnoreCase(tagNames);
     }
 
     @Override

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyTagJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyTagJpaRepository.java
@@ -3,5 +3,8 @@ package org.forif_backend.infrastructure.persistence.study;
 import org.forif_backend.domain.study.StudyTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudyTagJpaRepository extends JpaRepository<StudyTag, Long> {
+    List<StudyTag> findByNameIn(List<String> names);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyTagJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyTagJpaRepository.java
@@ -2,9 +2,12 @@ package org.forif_backend.infrastructure.persistence.study;
 
 import org.forif_backend.domain.study.StudyTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface StudyTagJpaRepository extends JpaRepository<StudyTag, Long> {
-    List<StudyTag> findByNameIn(List<String> names);
+    @Query("select st from StudyTag st where lower(st.name) in :names")
+    List<StudyTag> findByNameInIgnoreCase(@Param("names") List<String> names);
 }

--- a/src/main/java/org/forif_backend/web/study/StudyController.java
+++ b/src/main/java/org/forif_backend/web/study/StudyController.java
@@ -112,7 +112,7 @@ public class StudyController {
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<Void>> updateStudy(
             @Parameter(description = "수정할 스터디 ID") @PathVariable Integer studyId,
-            @RequestBody UpdateStudyRequest request
+            @RequestBody @Valid UpdateStudyRequest request
     ) {
         studyService.updateStudy(studyId, request);
         return ResponseEntity.ok(ApiResponse.success(null));

--- a/src/main/java/org/forif_backend/web/study/dto/CreateStudyApplyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/CreateStudyApplyRequest.java
@@ -30,6 +30,15 @@ public class CreateStudyApplyRequest {
     @Size(min = 1, message = "스터디 태그는 최소 1개 이상 선택해야 합니다.")
     private List<Long> studyTagId;          // 스터디 태그 id
 
+    @Size(min = 1, message = "스터디 태그는 최소 1개 이상 선택해야 합니다.")
+    private List<@NotBlank String> studyTagNames; // 스터디 태그 이름
+
+    @AssertTrue(message = "스터디 태그는 최소 1개 이상 선택해야 합니다.")
+    public boolean isStudyTagProvided() {
+        return (studyTagId != null && !studyTagId.isEmpty())
+                || (studyTagNames != null && !studyTagNames.isEmpty());
+    }
+
     @NotBlank
     @Length(min = 50, max = 500, message = "스터디 목표는 50자 이상 500자 이내로 작성해주세요.")
     private String goal;                    // 스터디 목표

--- a/src/main/java/org/forif_backend/web/study/dto/StudyDetailResponse.java
+++ b/src/main/java/org/forif_backend/web/study/dto/StudyDetailResponse.java
@@ -34,6 +34,7 @@ public record StudyDetailResponse(
         String selectionCriteria,
         Integer capacity,
         Boolean requiresInterview,
+        LocalDateTime interviewDate,
         List<PlanResponse> plans,
         List<ReferenceResponse> references,
         List<MentorInfo> mentors
@@ -107,6 +108,7 @@ public record StudyDetailResponse(
                 dto.getSelectionCriteria(),
                 dto.getCapacity(),
                 dto.getRequiresInterview(),
+                dto.getInterviewDate(),
                 dto.getPlans().stream().map(PlanResponse::from).toList(),
                 dto.getReferences().stream().map(ReferenceResponse::from).toList(),
                 dto.getMentors().stream().map(MentorInfo::from).toList()

--- a/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
@@ -33,6 +33,7 @@ public class UpdateStudyRequest {
     private LocalDateTime interviewDate;
 
     private List<Long> studyTagIds;
+    private List<String> studyTagNames;
     private List<Plan> studyPlanList;
     private List<Reference> references;
 

--- a/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
@@ -3,6 +3,7 @@ package org.forif_backend.web.study.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import jakarta.validation.constraints.NotBlank;
 import org.forif_backend.domain.study.ReferenceType;
 
 import java.time.LocalDateTime;
@@ -33,7 +34,7 @@ public class UpdateStudyRequest {
     private LocalDateTime interviewDate;
 
     private List<Long> studyTagIds;
-    private List<String> studyTagNames;
+    private List<@NotBlank String> studyTagNames;
     private List<Plan> studyPlanList;
     private List<Reference> references;
 

--- a/src/test/java/org/forif_backend/application/study/StudyServiceTagUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceTagUpdateTest.java
@@ -1,0 +1,88 @@
+package org.forif_backend.application.study;
+
+import org.forif_backend.application.file.port.out.FilePort;
+import org.forif_backend.application.semester.SemesterPhaseGuard;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.staff.StaffAccountService;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.StudyTag;
+import org.forif_backend.domain.study.StudyUserRepository;
+import org.forif_backend.domain.user.UserRepository;
+import org.forif_backend.web.study.dto.UpdateStudyRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StudyServiceTagUpdateTest {
+
+    private final StudyRepository studyRepository = mock(StudyRepository.class);
+    private StudyService studyService;
+
+    @BeforeEach
+    void setUp() {
+        studyService = new StudyService(
+                mock(SemesterService.class),
+                mock(SemesterPhaseGuard.class),
+                mock(StudyRecruitStatusPolicy.class),
+                studyRepository,
+                mock(StudyUserRepository.class),
+                mock(UserRepository.class),
+                mock(FilePort.class),
+                mock(StaffAccountService.class),
+                mock(StaffAccountRepository.class)
+        );
+    }
+
+    @Test
+    void clearsAllTagsWhenAnEmptyTagIdListIsProvided() {
+        Study study = mock(Study.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setStudyTagIds(List.of());
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+
+        studyService.updateStudy(1, request);
+
+        verify(study).setTags(List.of());
+    }
+
+    @Test
+    void resolvesCaseVariantsAsOneTag() {
+        Study study = mock(Study.class);
+        StudyTag tag = mock(StudyTag.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setStudyTagNames(List.of(" AI ", "ai"));
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(studyRepository.findAllStudyTagByName(List.of("ai"))).thenReturn(List.of(tag));
+
+        studyService.updateStudy(1, request);
+
+        verify(studyRepository).findAllStudyTagByName(List.of("ai"));
+        verify(study).setTags(List.of(tag));
+    }
+
+    @Test
+    void rejectsNullTagNamesInsteadOfThrowingNullPointerException() {
+        Study study = mock(Study.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setStudyTagNames(Arrays.asList("ai", null));
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+
+        assertThatThrownBy(() -> studyService.updateStudy(1, request))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_INPUT));
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 스터디 개설·재신청 시 태그 ID 대신 태그명을 전달하도록 변경
- 백엔드에서 태그명을 실제 태그 ID로 조회한 뒤 스터디 태그 매핑 저장
- 요청한 태그를 모두 찾지 못하면 빈 태그로 저장하지 않고 요청 실패
- 운영진 수정 API도 태그명 기반 매핑을 지원하도록 보완
- 스터디 상세 응답에 `interview_date` 추가

## 기대 효과

- DB별 태그 ID 차이로 신규 스터디의 태그가 빈 배열로 저장되는 문제 방지
- 스터디 목록·상세·운영진 승인 화면에서 일관되게 태그를 조회 가능
- 운영진이 승인 상세에서 면접 일정을 확인 가능

## 호환성

- 기존 `study_tag_ids` 요청은 계속 지원합니다.
- 상세 API에는 `interview_date`만 추가되며 기존 응답 필드는 변경하지 않았습니다.