### PR TITLE
fix(study): 신청서 수정 시 변경된 항목만 반영

### DIFF
--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -220,6 +220,10 @@ public class StudyService {
         Study study = studyRepository.findStudyByIdWithTags(studyId)
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
+        applyStudyUpdate(studyId, study, request);
+    }
+
+    private void applyStudyUpdate(Integer studyId, Study study, UpdateStudyRequest request) {
         // null이 아닌 기본 필드만 반영
         if (request.getStudyName() != null) study.setStudyName(request.getStudyName());
         if (request.getOneLiner() != null) study.setOneLiner(request.getOneLiner());
@@ -234,7 +238,11 @@ public class StudyService {
         if (request.getCapacity() != null) study.setCapacity(request.getCapacity());
         if (request.getSelectionCriteria() != null) study.setSelectionCriteria(request.getSelectionCriteria());
         if (request.getRequiresInterview() != null) study.setRequiresInterview(request.getRequiresInterview());
-        if (request.getInterviewDate() != null) study.setInterviewDate(request.getInterviewDate());
+        if (Boolean.FALSE.equals(request.getRequiresInterview())) {
+            study.setInterviewDate(null);
+        } else if (request.getInterviewDate() != null) {
+            study.setInterviewDate(request.getInterviewDate());
+        }
 
         // enum 변환 필드
         if (request.getDifficulty() != null) {
@@ -462,26 +470,30 @@ public class StudyService {
     }
 
     @Transactional
-    public CreateStudyApplyInfo updateStudyApplication(Integer studyId, Long userId, CreateStudyApplyRequest request,
+    public CreateStudyApplyInfo updateStudyApplication(Integer studyId, Long userId, UpdateStudyRequest request,
                                                         MultipartFile thumbnail, List<MultipartFile> referenceFiles) {
-        return updateStudyApplication(studyId, userId, request, thumbnail, referenceFiles, false);
+        Study study = findModifiableStudyApplication(studyId, userId, false);
+        applyStudyUpdate(studyId, study, request);
+
+        FileInfo thumbnailInfo = null;
+        if (thumbnail != null && !thumbnail.isEmpty()) {
+            thumbnailInfo = uploadAndBuildFileInfo(thumbnail);
+            study.setThumbnailImage(thumbnailInfo.objectKey());
+        }
+
+        studyRepository.saveStudy(study);
+
+        return CreateStudyApplyInfo.builder()
+                .studyId(study.getId())
+                .thumbnailUploadInfo(thumbnailInfo)
+                .referenceUploadInfos(List.of())
+                .build();
     }
 
     private CreateStudyApplyInfo updateStudyApplication(Integer studyId, Long userId, CreateStudyApplyRequest request,
                                                          MultipartFile thumbnail, List<MultipartFile> referenceFiles,
                                                          boolean rejectedOnly) {
-        Study study = studyRepository.findStudyByIdWithTags(studyId)
-                .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
-
-        studyMentorAccess.requireMentorOfActiveSemester(study, userId);
-        semesterPhaseGuard.requireOpen(SemesterPhase.MENTOR_RECRUIT);
-
-        if (rejectedOnly || study.getStudyStatus() == StudyStatus.REJECTED) {
-            study.reApply();
-        } else if (study.getStudyStatus() != StudyStatus.PENDING
-                && study.getStudyStatus() != StudyStatus.RE_APPLIED) {
-            throw new ForifException(ErrorCode.BAD_REQUEST);
-        }
+        Study study = findModifiableStudyApplication(studyId, userId, rejectedOnly);
 
         List<StudyTag> tags = resolveStudyTags(request);
         User secondaryMentor = resolveSecondaryMentor(study.getPrimaryMentor().getId(), request.getSecondaryMentorId());
@@ -495,6 +507,23 @@ public class StudyService {
         }
 
         return saveStudyWithResources(study, request, thumbnail, referenceFiles);
+    }
+
+    private Study findModifiableStudyApplication(Integer studyId, Long userId, boolean rejectedOnly) {
+        Study study = studyRepository.findStudyByIdWithTags(studyId)
+                .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
+
+        studyMentorAccess.requireMentorOfActiveSemester(study, userId);
+        semesterPhaseGuard.requireOpen(SemesterPhase.MENTOR_RECRUIT);
+
+        if (rejectedOnly || study.getStudyStatus() == StudyStatus.REJECTED) {
+            study.reApply();
+        } else if (study.getStudyStatus() != StudyStatus.PENDING
+                && study.getStudyStatus() != StudyStatus.RE_APPLIED) {
+            throw new ForifException(ErrorCode.BAD_REQUEST);
+        }
+
+        return study;
     }
 
     private boolean canModifyStudyApplication(Study study) {

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -182,7 +182,13 @@ public class StudyService {
         List<StudyReference> references = studyRepository.findStudyReferencesByStudyId(studyId);
         List<MentorStudy> mentorStudies = studyRepository.findMentorStudiesByStudyId(studyId);
 
-        return StudyDetailDto.of(study, plans, references, mentorStudies);
+        return StudyDetailDto.of(
+                study,
+                plans,
+                references,
+                mentorStudies,
+                resolveThumbnailImage(study)
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -239,6 +239,7 @@ public class StudyService {
                     request.getReferences(),
                     request.getRetainedReferenceIds(),
                     List.of(),
+                    true,
                     true
             );
         }
@@ -504,6 +505,7 @@ public class StudyService {
                         request.getReferences(),
                         request.getRetainedReferenceIds(),
                         Optional.ofNullable(referenceFiles).orElseGet(Collections::emptyList),
+                        false,
                         false
                 );
 
@@ -533,18 +535,19 @@ public class StudyService {
             List<UpdateStudyRequest.Reference> newReferences,
             List<UUID> retainedReferenceIds,
             List<MultipartFile> referenceFiles,
-            boolean skipUnuploadedFileReferences
+            boolean skipUnuploadedFileReferences,
+            boolean retainExistingFilesWhenRetainedIdsOmitted
     ) {
         List<StudyReference> existingReferences = studyRepository.findStudyReferencesByStudyId(studyId);
         Map<UUID, StudyReference> existingById = existingReferences.stream()
                 .collect(Collectors.toMap(StudyReference::getId, reference -> reference));
-        // retained_reference_ids를 보내지 않은 기존 어드민 클라이언트는 FILE 참고자료를 유지한다.
-        Set<UUID> retainedIds = retainedReferenceIds == null
+        // 구형 어드민 JSON 클라이언트만 retained_reference_ids 생략 시 FILE 참고자료를 유지한다.
+        Set<UUID> retainedIds = retainedReferenceIds == null && retainExistingFilesWhenRetainedIdsOmitted
                 ? existingReferences.stream()
                 .filter(reference -> reference.getReferenceType() == ReferenceType.FILE)
                 .map(StudyReference::getId)
                 .collect(Collectors.toCollection(LinkedHashSet::new))
-                : new LinkedHashSet<>(retainedReferenceIds);
+                : new LinkedHashSet<>(Optional.ofNullable(retainedReferenceIds).orElseGet(Collections::emptyList));
 
         if (!existingById.keySet().containsAll(retainedIds)) {
             throw new ForifException(ErrorCode.BAD_REQUEST);
@@ -637,11 +640,30 @@ public class StudyService {
         if (request.getStudyPlanList() != null) {
             studyRepository.deleteStudyPlansByStudyId(studyId);
         }
+        List<String> previousReferenceObjectKeys = List.of();
         if (request.getReferences() != null) {
+            previousReferenceObjectKeys = studyRepository.findStudyReferencesByStudyId(studyId).stream()
+                    .filter(reference -> reference.getReferenceType() == ReferenceType.FILE)
+                    .map(StudyReference::getContent)
+                    .toList();
             studyRepository.deleteStudyReferencesByStudyId(studyId);
         }
 
-        return saveStudyWithResources(study, request, thumbnail, referenceFiles);
+        String previousThumbnailObjectKey = thumbnail != null && !thumbnail.isEmpty()
+                ? study.getThumbnailImage()
+                : null;
+        CreateStudyApplyInfo result = saveStudyWithResources(study, request, thumbnail, referenceFiles);
+        List<String> previousObjectKeys = new ArrayList<>(previousReferenceObjectKeys);
+        previousObjectKeys.add(previousThumbnailObjectKey);
+        List<String> uploadedObjectKeys = new ArrayList<>(result.referenceUploadInfos().stream()
+                .map(FileInfo::objectKey)
+                .toList());
+        if (result.thumbnailUploadInfo() != null) {
+            uploadedObjectKeys.add(result.thumbnailUploadInfo().objectKey());
+        }
+        deleteStoredFilesAfterCompletion(previousObjectKeys, uploadedObjectKeys);
+
+        return result;
     }
 
     private Study findModifiableStudyApplication(Integer studyId, Long userId, boolean rejectedOnly) {

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -258,11 +258,13 @@ public class StudyService {
         if (request.getIsOnline() != null) study.setIsOnline(request.getIsOnline());
         if (request.getCapacity() != null) study.setCapacity(request.getCapacity());
         if (request.getSelectionCriteria() != null) study.setSelectionCriteria(request.getSelectionCriteria());
-        if (request.getSecondaryMentorId() != null) {
-            User secondaryMentor = resolveSecondaryMentor(
+        if (request.isSecondaryMentorIdPresent()) {
+            User secondaryMentor = request.getSecondaryMentorId() == null
+                    ? null
+                    : resolveSecondaryMentor(
                     study.getPrimaryMentor().getId(), request.getSecondaryMentorId());
             study.setSecondaryMentor(secondaryMentor);
-            study.setSecondaryMentorName(secondaryMentor.getUserName());
+            study.setSecondaryMentorName(secondaryMentor == null ? null : secondaryMentor.getUserName());
         }
         if (request.getRequiresInterview() != null) study.setRequiresInterview(request.getRequiresInterview());
         if (Boolean.FALSE.equals(request.getRequiresInterview())) {

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -25,6 +25,8 @@ import org.forif_backend.web.study.dto.CreateStudyApplyRequest;
 import org.forif_backend.web.study.dto.UpdateStudyRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -236,7 +238,8 @@ public class StudyService {
                     study,
                     request.getReferences(),
                     request.getRetainedReferenceIds(),
-                    List.of()
+                    List.of(),
+                    true
             );
         }
     }
@@ -255,6 +258,12 @@ public class StudyService {
         if (request.getIsOnline() != null) study.setIsOnline(request.getIsOnline());
         if (request.getCapacity() != null) study.setCapacity(request.getCapacity());
         if (request.getSelectionCriteria() != null) study.setSelectionCriteria(request.getSelectionCriteria());
+        if (request.getSecondaryMentorId() != null) {
+            User secondaryMentor = resolveSecondaryMentor(
+                    study.getPrimaryMentor().getId(), request.getSecondaryMentorId());
+            study.setSecondaryMentor(secondaryMentor);
+            study.setSecondaryMentorName(secondaryMentor.getUserName());
+        }
         if (request.getRequiresInterview() != null) study.setRequiresInterview(request.getRequiresInterview());
         if (Boolean.FALSE.equals(request.getRequiresInterview())) {
             study.setInterviewDate(null);
@@ -492,13 +501,19 @@ public class StudyService {
                         study,
                         request.getReferences(),
                         request.getRetainedReferenceIds(),
-                        Optional.ofNullable(referenceFiles).orElseGet(Collections::emptyList)
+                        Optional.ofNullable(referenceFiles).orElseGet(Collections::emptyList),
+                        false
                 );
 
         FileInfo thumbnailInfo = null;
         if (thumbnail != null && !thumbnail.isEmpty()) {
+            String previousThumbnailObjectKey = study.getThumbnailImage();
             thumbnailInfo = uploadAndBuildFileInfo(thumbnail);
             study.setThumbnailImage(thumbnailInfo.objectKey());
+            deleteStoredFilesAfterCompletion(
+                    Collections.singletonList(previousThumbnailObjectKey),
+                    List.of(thumbnailInfo.objectKey())
+            );
         }
 
         studyRepository.saveStudy(study);
@@ -515,22 +530,28 @@ public class StudyService {
             Study study,
             List<UpdateStudyRequest.Reference> newReferences,
             List<UUID> retainedReferenceIds,
-            List<MultipartFile> referenceFiles
+            List<MultipartFile> referenceFiles,
+            boolean skipUnuploadedFileReferences
     ) {
         List<StudyReference> existingReferences = studyRepository.findStudyReferencesByStudyId(studyId);
         Map<UUID, StudyReference> existingById = existingReferences.stream()
                 .collect(Collectors.toMap(StudyReference::getId, reference -> reference));
-        Set<UUID> retainedIds = new LinkedHashSet<>(Optional.ofNullable(retainedReferenceIds).orElseGet(List::of));
+        // retained_reference_ids를 보내지 않은 기존 어드민 클라이언트는 FILE 참고자료를 유지한다.
+        Set<UUID> retainedIds = retainedReferenceIds == null
+                ? existingReferences.stream()
+                .filter(reference -> reference.getReferenceType() == ReferenceType.FILE)
+                .map(StudyReference::getId)
+                .collect(Collectors.toCollection(LinkedHashSet::new))
+                : new LinkedHashSet<>(retainedReferenceIds);
 
         if (!existingById.keySet().containsAll(retainedIds)) {
             throw new ForifException(ErrorCode.BAD_REQUEST);
         }
 
-        List<StudyReference> references = new ArrayList<>();
-        for (UUID retainedId : retainedIds) {
-            StudyReference reference = existingById.get(retainedId);
-            references.add(StudyReference.create(study, reference.getReferenceType(), reference.getContent()));
-        }
+        List<StudyReference> removedReferences = existingReferences.stream()
+                .filter(reference -> !retainedIds.contains(reference.getId()))
+                .toList();
+        List<StudyReference> referencesToCreate = new ArrayList<>();
 
         List<FileInfo> uploadedFiles = new ArrayList<>();
         for (UpdateStudyRequest.Reference reference : newReferences) {
@@ -538,18 +559,68 @@ public class StudyService {
                 MultipartFile file = referenceFiles.stream()
                         .filter(candidate -> Objects.equals(candidate.getOriginalFilename(), reference.getFileName()))
                         .findFirst()
-                        .orElseThrow(() -> new ForifException(ErrorCode.INVALID_FILE_ATTACHMENT));
-                FileInfo fileInfo = uploadAndBuildFileInfo(file);
-                uploadedFiles.add(fileInfo);
-                references.add(StudyReference.create(study, ReferenceType.FILE, fileInfo.objectKey()));
+                        .orElse(null);
+                if (file != null) {
+                    FileInfo fileInfo = uploadAndBuildFileInfo(file);
+                    uploadedFiles.add(fileInfo);
+                    referencesToCreate.add(StudyReference.create(study, ReferenceType.FILE, fileInfo.objectKey()));
+                } else if (!skipUnuploadedFileReferences) {
+                    throw new ForifException(ErrorCode.INVALID_FILE_ATTACHMENT);
+                }
+                // JSON 어드민 수정은 조회용 FILE URL을 저장하지 않는다. 기존 FILE은 retained 정책으로 유지된다.
             } else {
-                references.add(StudyReference.create(study, reference.getType(), reference.getUrl()));
+                referencesToCreate.add(StudyReference.create(study, reference.getType(), reference.getUrl()));
             }
         }
 
-        studyRepository.deleteStudyReferencesByStudyId(studyId);
-        studyRepository.saveAllStudyReference(references);
+        if (!removedReferences.isEmpty()) {
+            studyRepository.deleteStudyReferencesByIds(removedReferences.stream()
+                    .map(StudyReference::getId)
+                    .toList());
+        }
+        if (!referencesToCreate.isEmpty()) {
+            studyRepository.saveAllStudyReference(referencesToCreate);
+        }
+        deleteStoredFilesAfterCompletion(
+                removedReferences.stream()
+                        .filter(reference -> reference.getReferenceType() == ReferenceType.FILE)
+                        .map(StudyReference::getContent)
+                        .toList(),
+                uploadedFiles.stream().map(FileInfo::objectKey).toList()
+        );
         return uploadedFiles;
+    }
+
+    /** DB 반영 성공 뒤 교체 전 파일을 지우고, 롤백 시 새로 올린 파일을 회수한다. */
+    private void deleteStoredFilesAfterCompletion(List<String> previousObjectKeys, List<String> uploadedObjectKeys) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_COMMITTED) {
+                    deleteStoredFilesQuietly(previousObjectKeys);
+                } else {
+                    deleteStoredFilesQuietly(uploadedObjectKeys);
+                }
+            }
+        });
+    }
+
+    private void deleteStoredFilesQuietly(List<String> objectKeys) {
+        for (String objectKey : objectKeys) {
+            if (objectKey == null || objectKey.isBlank()
+                    || objectKey.startsWith("http://") || objectKey.startsWith("https://")) {
+                continue;
+            }
+            try {
+                filePort.deleteFile(objectKey);
+            } catch (Exception e) {
+                log.warn("스터디 수정 중 파일 삭제 실패: {}", objectKey, e);
+            }
+        }
     }
 
     private CreateStudyApplyInfo updateStudyApplication(Integer studyId, Long userId, CreateStudyApplyRequest request,
@@ -605,8 +676,8 @@ public class StudyService {
      */
     private CreateStudyApplyInfo saveStudyWithResources(Study study, CreateStudyApplyRequest request,
                                                         MultipartFile thumbnail, List<MultipartFile> referenceFiles) {
-        // 썸네일 처리
         FileInfo thumbnailInfo = null;
+        // 썸네일 처리
         if (thumbnail != null && !thumbnail.isEmpty()) {
             thumbnailInfo = uploadAndBuildFileInfo(thumbnail);
             study.setThumbnailImage(thumbnailInfo.objectKey());

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -181,13 +181,16 @@ public class StudyService {
         List<StudyPlan> plans = studyRepository.findStudyPlansByStudyId(studyId);
         List<StudyReference> references = studyRepository.findStudyReferencesByStudyId(studyId);
         List<MentorStudy> mentorStudies = studyRepository.findMentorStudiesByStudyId(studyId);
+        Map<UUID, String> referenceContents = references.stream()
+                .collect(Collectors.toMap(StudyReference::getId, this::resolveReferenceContent));
 
         return StudyDetailDto.of(
                 study,
                 plans,
                 references,
                 mentorStudies,
-                resolveThumbnailImage(study)
+                resolveThumbnailImage(study),
+                referenceContents
         );
     }
 
@@ -227,6 +230,15 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         applyStudyUpdate(studyId, study, request);
+        if (request.getReferences() != null) {
+            replaceStudyReferences(
+                    studyId,
+                    study,
+                    request.getReferences(),
+                    request.getRetainedReferenceIds(),
+                    List.of()
+            );
+        }
     }
 
     private void applyStudyUpdate(Integer studyId, Study study, UpdateStudyRequest request) {
@@ -270,14 +282,6 @@ public class StudyService {
             studyRepository.saveAllStudyPlan(plans);
         }
 
-        // 참고자료: 기존 삭제 후 재생성
-        if (request.getReferences() != null) {
-            studyRepository.deleteStudyReferencesByStudyId(studyId);
-            List<StudyReference> references = request.getReferences().stream()
-                    .map(ref -> StudyReference.create(study, ref.getType(), ref.getUrl()))
-                    .toList();
-            studyRepository.saveAllStudyReference(references);
-        }
     }
 
     @Transactional
@@ -481,6 +485,16 @@ public class StudyService {
         Study study = findModifiableStudyApplication(studyId, userId, false);
         applyStudyUpdate(studyId, study, request);
 
+        List<FileInfo> referenceUploadInfos = request.getReferences() == null
+                ? List.of()
+                : replaceStudyReferences(
+                        studyId,
+                        study,
+                        request.getReferences(),
+                        request.getRetainedReferenceIds(),
+                        Optional.ofNullable(referenceFiles).orElseGet(Collections::emptyList)
+                );
+
         FileInfo thumbnailInfo = null;
         if (thumbnail != null && !thumbnail.isEmpty()) {
             thumbnailInfo = uploadAndBuildFileInfo(thumbnail);
@@ -492,8 +506,50 @@ public class StudyService {
         return CreateStudyApplyInfo.builder()
                 .studyId(study.getId())
                 .thumbnailUploadInfo(thumbnailInfo)
-                .referenceUploadInfos(List.of())
+                .referenceUploadInfos(referenceUploadInfos)
                 .build();
+    }
+
+    private List<FileInfo> replaceStudyReferences(
+            Integer studyId,
+            Study study,
+            List<UpdateStudyRequest.Reference> newReferences,
+            List<UUID> retainedReferenceIds,
+            List<MultipartFile> referenceFiles
+    ) {
+        List<StudyReference> existingReferences = studyRepository.findStudyReferencesByStudyId(studyId);
+        Map<UUID, StudyReference> existingById = existingReferences.stream()
+                .collect(Collectors.toMap(StudyReference::getId, reference -> reference));
+        Set<UUID> retainedIds = new LinkedHashSet<>(Optional.ofNullable(retainedReferenceIds).orElseGet(List::of));
+
+        if (!existingById.keySet().containsAll(retainedIds)) {
+            throw new ForifException(ErrorCode.BAD_REQUEST);
+        }
+
+        List<StudyReference> references = new ArrayList<>();
+        for (UUID retainedId : retainedIds) {
+            StudyReference reference = existingById.get(retainedId);
+            references.add(StudyReference.create(study, reference.getReferenceType(), reference.getContent()));
+        }
+
+        List<FileInfo> uploadedFiles = new ArrayList<>();
+        for (UpdateStudyRequest.Reference reference : newReferences) {
+            if (reference.getType() == ReferenceType.FILE) {
+                MultipartFile file = referenceFiles.stream()
+                        .filter(candidate -> Objects.equals(candidate.getOriginalFilename(), reference.getFileName()))
+                        .findFirst()
+                        .orElseThrow(() -> new ForifException(ErrorCode.INVALID_FILE_ATTACHMENT));
+                FileInfo fileInfo = uploadAndBuildFileInfo(file);
+                uploadedFiles.add(fileInfo);
+                references.add(StudyReference.create(study, ReferenceType.FILE, fileInfo.objectKey()));
+            } else {
+                references.add(StudyReference.create(study, reference.getType(), reference.getUrl()));
+            }
+        }
+
+        studyRepository.deleteStudyReferencesByStudyId(studyId);
+        studyRepository.saveAllStudyReference(references);
+        return uploadedFiles;
     }
 
     private CreateStudyApplyInfo updateStudyApplication(Integer studyId, Long userId, CreateStudyApplyRequest request,
@@ -618,6 +674,18 @@ public class StudyService {
             return thumbnailImage;
         }
         return filePort.generatePresignedViewUrl(thumbnailImage).presignedUrl();
+    }
+
+    private String resolveReferenceContent(StudyReference reference) {
+        String content = reference.getContent();
+        if (reference.getReferenceType() != ReferenceType.FILE
+                || content == null
+                || content.isBlank()
+                || content.startsWith("http://")
+                || content.startsWith("https://")) {
+            return content;
+        }
+        return filePort.generatePresignedViewUrl(content).presignedUrl();
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/study/dto/StudyDetailDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyDetailDto.java
@@ -7,6 +7,8 @@ import org.forif_backend.domain.study.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Getter
 @RequiredArgsConstructor
@@ -50,6 +52,14 @@ public class StudyDetailDto {
                                      List<StudyReference> references,
                                      List<MentorStudy> mentorStudies,
                                      String thumbnailImage) {
+        return of(study, plans, references, mentorStudies, thumbnailImage, Map.of());
+    }
+
+    public static StudyDetailDto of(Study study, List<StudyPlan> plans,
+                                     List<StudyReference> references,
+                                     List<MentorStudy> mentorStudies,
+                                     String thumbnailImage,
+                                     Map<UUID, String> referenceContents) {
         return StudyDetailDto.builder()
                 .id(study.getId())
                 .actYear(study.getActYear())
@@ -76,7 +86,12 @@ public class StudyDetailDto {
                 .requiresInterview(study.getRequiresInterview())
                 .interviewDate(study.getInterviewDate())
                 .plans(plans.stream().map(StudyPlanDto::from).toList())
-                .references(references.stream().map(StudyReferenceDto::from).toList())
+                .references(references.stream()
+                        .map(reference -> StudyReferenceDto.from(
+                                reference,
+                                referenceContents.getOrDefault(reference.getId(), reference.getContent())
+                        ))
+                        .toList())
                 .mentors(mentorStudies.stream().map(MentorStudyDto::from).toList())
                 .build();
     }

--- a/src/main/java/org/forif_backend/application/study/dto/StudyDetailDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyDetailDto.java
@@ -43,6 +43,13 @@ public class StudyDetailDto {
     public static StudyDetailDto of(Study study, List<StudyPlan> plans,
                                      List<StudyReference> references,
                                      List<MentorStudy> mentorStudies) {
+        return of(study, plans, references, mentorStudies, study.getThumbnailImage());
+    }
+
+    public static StudyDetailDto of(Study study, List<StudyPlan> plans,
+                                     List<StudyReference> references,
+                                     List<MentorStudy> mentorStudies,
+                                     String thumbnailImage) {
         return StudyDetailDto.builder()
                 .id(study.getId())
                 .actYear(study.getActYear())
@@ -61,7 +68,7 @@ public class StudyDetailDto {
                 .locationDetail(study.getLocationDetail())
                 .difficulty(study.getDifficulty())
                 .imgUrl(study.getImgUrl())
-                .thumbnailImage(study.getThumbnailImage())
+                .thumbnailImage(thumbnailImage)
                 .isOnline(study.getIsOnline())
                 .goal(study.getGoal())
                 .selectionCriteria(study.getSelectionCriteria())

--- a/src/main/java/org/forif_backend/application/study/dto/StudyReferenceDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyReferenceDto.java
@@ -17,10 +17,14 @@ public class StudyReferenceDto {
     private final String content;
 
     public static StudyReferenceDto from(StudyReference reference) {
+        return from(reference, reference.getContent());
+    }
+
+    public static StudyReferenceDto from(StudyReference reference, String content) {
         return StudyReferenceDto.builder()
                 .id(reference.getId())
                 .referenceType(reference.getReferenceType())
-                .content(reference.getContent())
+                .content(content)
                 .build();
     }
 }

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -3,6 +3,7 @@ package org.forif_backend.domain.study;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface StudyRepository {
     Optional<Study> findStudyById(Integer studyId);
@@ -116,6 +117,11 @@ public interface StudyRepository {
      * 스터디 ID에 해당하는 참고자료 전체 삭제
      */
     void deleteStudyReferencesByStudyId(Integer studyId);
+
+    /**
+     * 지정한 참고자료만 삭제한다.
+     */
+    void deleteStudyReferencesByIds(List<UUID> referenceIds);
 
     /**
      * 스터디 ID에 해당하는 수강생 전체 삭제

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyReferenceJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyReferenceJpaRepository.java
@@ -11,4 +11,5 @@ public interface StudyReferenceJpaRepository extends JpaRepository<StudyReferenc
     List<StudyReference> findByStudy(Study study);
     List<StudyReference> findByStudyId(Integer studyId);
     void deleteByStudyId(Integer studyId);
+    void deleteByIdIn(List<UUID> referenceIds);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.forif_backend.infrastructure.persistence.study;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.domain.study.*;
@@ -175,6 +176,16 @@ public class StudyRepositoryImpl implements StudyRepository {
     @Override
     public void deleteStudyReferencesByStudyId(Integer studyId) {
         studyReferenceJpaRepository.deleteByStudyId(studyId);
+        studyReferenceJpaRepository.flush();
+    }
+
+    @Override
+    public void deleteStudyReferencesByIds(List<UUID> referenceIds) {
+        if (referenceIds.isEmpty()) {
+            return;
+        }
+        studyReferenceJpaRepository.deleteByIdIn(referenceIds);
+        studyReferenceJpaRepository.flush();
     }
 
     @Override

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -169,6 +169,7 @@ public class StudyRepositoryImpl implements StudyRepository {
     @Override
     public void deleteStudyPlansByStudyId(Integer studyId) {
         studyPlanJpaRepository.deleteByStudyId(studyId);
+        studyPlanJpaRepository.flush();
     }
 
     @Override

--- a/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
@@ -8,6 +8,7 @@ import org.forif_backend.domain.study.ReferenceType;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -37,6 +38,7 @@ public class UpdateStudyRequest {
     private List<@NotBlank String> studyTagNames;
     private List<Plan> studyPlanList;
     private List<Reference> references;
+    private List<UUID> retainedReferenceIds;
 
     @Getter
     @Setter
@@ -54,5 +56,6 @@ public class UpdateStudyRequest {
     public static class Reference {
         private ReferenceType type;
         private String url;
+        private String fileName;
     }
 }

--- a/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
@@ -1,5 +1,6 @@
 package org.forif_backend.web.study.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class UpdateStudyRequest {
 
+    @JsonAlias("title")
     private String studyName;
     private String oneLiner;
     private String explanation;
@@ -24,7 +26,9 @@ public class UpdateStudyRequest {
     private String endTime;
     private Integer weekDay;
 
+    @JsonAlias("study_location")
     private String location;
+    @JsonAlias("study_location_detail")
     private String locationDetail;
     private Boolean isOnline;
 
@@ -34,8 +38,11 @@ public class UpdateStudyRequest {
     private Boolean requiresInterview;
     private LocalDateTime interviewDate;
 
+    @JsonAlias("study_tag_id")
     private List<Long> studyTagIds;
     private List<@NotBlank String> studyTagNames;
+    @JsonAlias("secondary_mentor_id")
+    private Long secondaryMentorId;
     private List<Plan> studyPlanList;
     private List<Reference> references;
     private List<UUID> retainedReferenceIds;

--- a/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
@@ -1,6 +1,8 @@
 package org.forif_backend.web.study.dto;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -41,11 +43,18 @@ public class UpdateStudyRequest {
     @JsonAlias("study_tag_id")
     private List<Long> studyTagIds;
     private List<@NotBlank String> studyTagNames;
-    @JsonAlias("secondary_mentor_id")
     private Long secondaryMentorId;
+    @JsonIgnore
+    private boolean secondaryMentorIdPresent;
     private List<Plan> studyPlanList;
     private List<Reference> references;
     private List<UUID> retainedReferenceIds;
+
+    @JsonSetter("secondary_mentor_id")
+    public void setSecondaryMentorId(Long secondaryMentorId) {
+        this.secondaryMentorId = secondaryMentorId;
+        this.secondaryMentorIdPresent = true;
+    }
 
     @Getter
     @Setter

--- a/src/main/java/org/forif_backend/web/studyApply/StudyApplyController.java
+++ b/src/main/java/org/forif_backend/web/studyApply/StudyApplyController.java
@@ -18,6 +18,7 @@ import org.forif_backend.web.study.dto.CreateStudyApplyRequest;
 import org.forif_backend.web.study.dto.CreateStudyApplyResponse;
 import org.forif_backend.web.study.dto.StudyApplicationDetailResponse;
 import org.forif_backend.web.study.dto.StudyApplicationResponse;
+import org.forif_backend.web.study.dto.UpdateStudyRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -103,12 +104,12 @@ public class StudyApplyController {
         )));
     }
 
-    @Operation(summary = "내 스터디 개설 신청 수정", description = "승인 전 본인 신청서만 수정할 수 있으며, 반려 건은 수정 후 재신청 상태로 전환됩니다.")
+    @Operation(summary = "내 스터디 개설 신청 수정", description = "승인 전 본인 신청서의 변경한 항목만 수정할 수 있으며, 반려 건은 수정 후 재신청 상태로 전환됩니다.")
     @PatchMapping(value = "/{studyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<CreateStudyApplyResponse>> updateStudyApplication(
             @PathVariable Integer studyId,
             @AuthenticationPrincipal Long userId,
-            @RequestPart("studyRequest") @Valid CreateStudyApplyRequest request,
+            @RequestPart("studyRequest") @Valid UpdateStudyRequest request,
             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
             @RequestPart(value = "references", required = false) List<MultipartFile> references
     ) {

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -13,9 +13,8 @@ import org.forif_backend.domain.study.StudyRepository;
 import org.forif_backend.domain.study.StudyStatus;
 import org.forif_backend.domain.study.StudyTag;
 import org.forif_backend.domain.study.StudyUserRepository;
-import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.UserRepository;
-import org.forif_backend.web.study.dto.CreateStudyApplyRequest;
+import org.forif_backend.web.study.dto.UpdateStudyRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,7 +77,7 @@ class StudyServiceApplicationUpdateTest {
                 .requireMentorOfActiveSemester(study, 10L);
 
         assertThatThrownBy(() -> studyService.updateStudyApplication(
-                1, 10L, new CreateStudyApplyRequest(), null, null))
+                1, 10L, new UpdateStudyRequest(), null, null))
                 .isInstanceOf(ForifException.class)
                 .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
                         .isEqualTo(ErrorCode.STUDY_NOT_IN_ACTIVE_SEMESTER));
@@ -106,20 +105,33 @@ class StudyServiceApplicationUpdateTest {
     @Test
     void keepsExistingPlansWhenTheUpdateRequestOmitsStudyPlanList() {
         Study study = mock(Study.class);
-        User primaryMentor = mock(User.class);
         StudyTag tag = mock(StudyTag.class);
-        CreateStudyApplyRequest request = new CreateStudyApplyRequest();
+        UpdateStudyRequest request = new UpdateStudyRequest();
         request.setStudyTagNames(List.of("ai"));
 
         when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
         when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
-        when(study.getPrimaryMentor()).thenReturn(primaryMentor);
-        when(primaryMentor.getId()).thenReturn(10L);
         when(studyRepository.findAllStudyTagByName(List.of("ai"))).thenReturn(List.of(tag));
 
         studyService.updateStudyApplication(1, 10L, request, null, null);
 
         verify(studyRepository, never()).deleteStudyPlansByStudyId(1);
         verify(studyRepository).findAllStudyTagByName(List.of("ai"));
+    }
+
+    @Test
+    void updatesOnlyExplanationWithoutReplacingPlans() {
+        Study study = mock(Study.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setExplanation("수정된 스터디 소개입니다. 충분히 긴 설명을 입력했습니다.");
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
+
+        studyService.updateStudyApplication(1, 10L, request, null, null);
+
+        verify(study).setExplanation(request.getExplanation());
+        verify(studyRepository, never()).deleteStudyPlansByStudyId(1);
+        verify(studyRepository, never()).saveAllStudyPlan(org.mockito.ArgumentMatchers.anyList());
     }
 }

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -150,6 +150,21 @@ class StudyServiceApplicationUpdateTest {
     }
 
     @Test
+    void removesSecondaryMentorWhenThePatchExplicitlySendsNull() {
+        Study study = mock(Study.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setSecondaryMentorId(null);
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
+
+        studyService.updateStudyApplication(1, 10L, request, null, null);
+
+        verify(study).setSecondaryMentor(null);
+        verify(study).setSecondaryMentorName(null);
+    }
+
+    @Test
     void keepsExistingFileReferencesWhenLegacyAdminRequestOmitsRetainedReferenceIds() {
         Study study = mock(Study.class);
         StudyReference fileReference = mock(StudyReference.class);

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -1,6 +1,7 @@
 package org.forif_backend.application.study;
 
 import org.forif_backend.application.file.port.out.FilePort;
+import org.forif_backend.application.file.dto.FileInfo;
 import org.forif_backend.application.semester.SemesterPhaseGuard;
 import org.forif_backend.application.semester.SemesterService;
 import org.forif_backend.application.semester.dto.SemesterInfo;
@@ -13,7 +14,9 @@ import org.forif_backend.domain.study.StudyRepository;
 import org.forif_backend.domain.study.StudyStatus;
 import org.forif_backend.domain.study.StudyTag;
 import org.forif_backend.domain.study.StudyUserRepository;
+import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.UserRepository;
+import org.forif_backend.web.study.dto.CreateStudyApplyRequest;
 import org.forif_backend.web.study.dto.UpdateStudyRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
@@ -38,6 +41,7 @@ import org.forif_backend.domain.study.ReferenceType;
 import org.forif_backend.domain.study.StudyReference;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class StudyServiceApplicationUpdateTest {
@@ -184,6 +188,77 @@ class StudyServiceApplicationUpdateTest {
 
         verify(studyRepository, never()).deleteStudyReferencesByIds(anyList());
         verify(studyRepository, never()).saveAllStudyReference(anyList());
+    }
+
+    @Test
+    void replacesExistingFileReferencesWhenMentorMultipartRequestOmitsRetainedReferenceIds() {
+        Study study = mock(Study.class);
+        StudyReference existingFileReference = mock(StudyReference.class);
+        UUID existingReferenceId = UUID.randomUUID();
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setReferences(List.of());
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
+        when(studyRepository.findStudyReferencesByStudyId(1)).thenReturn(List.of(existingFileReference));
+        when(existingFileReference.getId()).thenReturn(existingReferenceId);
+        when(existingFileReference.getReferenceType()).thenReturn(ReferenceType.FILE);
+        when(existingFileReference.getContent()).thenReturn("studies/references/old.pdf");
+        TransactionSynchronizationManager.initSynchronization();
+
+        studyService.updateStudyApplication(1, 10L, request, null, List.of());
+
+        verify(studyRepository).deleteStudyReferencesByIds(List.of(existingReferenceId));
+        TransactionSynchronizationManager.getSynchronizations()
+                .forEach(synchronization -> synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
+        verify(filePort).deleteFile("studies/references/old.pdf");
+    }
+
+    @Test
+    void deletesReplacedReferenceFilesAfterReapplying() {
+        Study study = mock(Study.class);
+        User primaryMentor = mock(User.class);
+        StudyReference existingFileReference = mock(StudyReference.class);
+        MultipartFile replacementFile = mock(MultipartFile.class);
+        MultipartFile replacementThumbnail = mock(MultipartFile.class);
+        CreateStudyApplyRequest request = new CreateStudyApplyRequest();
+        CreateStudyApplyRequest.Reference replacementReference = new CreateStudyApplyRequest.Reference();
+        replacementReference.setType(ReferenceType.FILE);
+        replacementReference.setFileName("replacement.pdf");
+        request.setReferences(List.of(replacementReference));
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getPrimaryMentor()).thenReturn(primaryMentor);
+        when(primaryMentor.getId()).thenReturn(10L);
+        when(study.getThumbnailImage()).thenReturn("studies/thumbnails/rejected.png");
+        when(studyRepository.findStudyReferencesByStudyId(1)).thenReturn(List.of(existingFileReference));
+        when(existingFileReference.getReferenceType()).thenReturn(ReferenceType.FILE);
+        when(existingFileReference.getContent()).thenReturn("studies/references/rejected.pdf");
+        when(replacementFile.getOriginalFilename()).thenReturn("replacement.pdf");
+        when(filePort.uploadFile(replacementFile)).thenReturn("studies/references/replacement.pdf");
+        when(filePort.generatePresignedViewUrl("studies/references/replacement.pdf"))
+                .thenReturn(new FileInfo("studies/references/replacement.pdf", "https://example.com/replacement.pdf"));
+        when(replacementThumbnail.isEmpty()).thenReturn(false);
+        when(filePort.uploadFile(replacementThumbnail)).thenReturn("studies/thumbnails/replacement.png");
+        when(filePort.generatePresignedViewUrl("studies/thumbnails/replacement.png"))
+                .thenReturn(new FileInfo("studies/thumbnails/replacement.png", "https://example.com/replacement.png"));
+        TransactionSynchronizationManager.initSynchronization();
+
+        studyService.reApplyStudy(1, 10L, request, replacementThumbnail, List.of(replacementFile));
+
+        verify(studyRepository).deleteStudyReferencesByStudyId(1);
+        verify(filePort).uploadFile(replacementFile);
+        verify(filePort).uploadFile(replacementThumbnail);
+        verify(filePort, never()).deleteFile("studies/references/rejected.pdf");
+        verify(filePort, never()).deleteFile("studies/thumbnails/rejected.png");
+
+        TransactionSynchronizationManager.getSynchronizations()
+                .forEach(synchronization -> synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
+
+        verify(filePort).deleteFile("studies/references/rejected.pdf");
+        verify(filePort).deleteFile("studies/thumbnails/rejected.png");
+        verify(filePort, never()).deleteFile("studies/references/replacement.pdf");
+        verify(filePort, never()).deleteFile("studies/thumbnails/replacement.png");
     }
 
     @Test

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -16,6 +16,7 @@ import org.forif_backend.domain.study.StudyUserRepository;
 import org.forif_backend.domain.user.UserRepository;
 import org.forif_backend.web.study.dto.UpdateStudyRequest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,14 +24,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.forif_backend.domain.study.ReferenceType;
+import org.forif_backend.domain.study.StudyReference;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
 class StudyServiceApplicationUpdateTest {
@@ -66,6 +73,13 @@ class StudyServiceApplicationUpdateTest {
                 staffAccountService,
                 staffAccountRepository
         );
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test
@@ -134,4 +148,59 @@ class StudyServiceApplicationUpdateTest {
         verify(studyRepository, never()).deleteStudyPlansByStudyId(1);
         verify(studyRepository, never()).saveAllStudyPlan(org.mockito.ArgumentMatchers.anyList());
     }
+
+    @Test
+    void keepsExistingFileReferencesWhenLegacyAdminRequestOmitsRetainedReferenceIds() {
+        Study study = mock(Study.class);
+        StudyReference fileReference = mock(StudyReference.class);
+        UUID referenceId = UUID.randomUUID();
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        UpdateStudyRequest.Reference fileReferenceRequest = new UpdateStudyRequest.Reference();
+        fileReferenceRequest.setType(ReferenceType.FILE);
+        fileReferenceRequest.setUrl("https://files.example.com/temporary-view-url");
+        request.setReferences(List.of(fileReferenceRequest));
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(studyRepository.findStudyReferencesByStudyId(1)).thenReturn(List.of(fileReference));
+        when(fileReference.getId()).thenReturn(referenceId);
+        when(fileReference.getReferenceType()).thenReturn(ReferenceType.FILE);
+
+        studyService.updateStudy(1, request);
+
+        verify(studyRepository, never()).deleteStudyReferencesByIds(anyList());
+        verify(studyRepository, never()).saveAllStudyReference(anyList());
+    }
+
+    @Test
+    void preservesRetainedReferenceIdAndDeletesOnlyRemovedFileAfterCommit() {
+        Study study = mock(Study.class);
+        StudyReference retainedReference = mock(StudyReference.class);
+        StudyReference removedFileReference = mock(StudyReference.class);
+        UUID retainedId = UUID.randomUUID();
+        UUID removedId = UUID.randomUUID();
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setReferences(List.of());
+        request.setRetainedReferenceIds(List.of(retainedId));
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(studyRepository.findStudyReferencesByStudyId(1))
+                .thenReturn(List.of(retainedReference, removedFileReference));
+        when(retainedReference.getId()).thenReturn(retainedId);
+        when(removedFileReference.getId()).thenReturn(removedId);
+        when(removedFileReference.getReferenceType()).thenReturn(ReferenceType.FILE);
+        when(removedFileReference.getContent()).thenReturn("studies/references/old.pdf");
+        TransactionSynchronizationManager.initSynchronization();
+
+        studyService.updateStudy(1, request);
+
+        verify(studyRepository).deleteStudyReferencesByIds(List.of(removedId));
+        verify(studyRepository, never()).saveAllStudyReference(anyList());
+        verify(filePort, never()).deleteFile("studies/references/old.pdf");
+
+        TransactionSynchronizationManager.getSynchronizations()
+                .forEach(synchronization -> synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
+
+        verify(filePort).deleteFile("studies/references/old.pdf");
+    }
+
 }

--- a/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImplUnitTest.java
+++ b/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImplUnitTest.java
@@ -1,0 +1,28 @@
+package org.forif_backend.infrastructure.persistence.study;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+class StudyRepositoryImplUnitTest {
+
+    @Test
+    @DisplayName("스터디 커리큘럼 삭제는 새 커리큘럼 저장 전에 반영되도록 flush한다")
+    void deleteStudyPlansByStudyId_flushesAfterDelete() {
+        // given
+        StudyPlanJpaRepository studyPlanJpaRepository = mock(StudyPlanJpaRepository.class);
+        StudyRepositoryImpl studyRepository = new StudyRepositoryImpl(
+                null, null, null, studyPlanJpaRepository, null, null, null);
+
+        // when
+        studyRepository.deleteStudyPlansByStudyId(112);
+
+        // then
+        InOrder inOrder = inOrder(studyPlanJpaRepository);
+        inOrder.verify(studyPlanJpaRepository).deleteByStudyId(112);
+        inOrder.verify(studyPlanJpaRepository).flush();
+    }
+}

--- a/src/test/java/org/forif_backend/web/study/dto/UpdateStudyRequestTest.java
+++ b/src/test/java/org/forif_backend/web/study/dto/UpdateStudyRequestTest.java
@@ -1,0 +1,34 @@
+package org.forif_backend.web.study.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateStudyRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+    @Test
+    void acceptsLegacyPatchFieldNames() throws Exception {
+        UpdateStudyRequest request = objectMapper.readValue("""
+                {
+                  "title": "기존 계약 스터디명",
+                  "study_location": "공학관",
+                  "study_location_detail": "301호",
+                  "study_tag_id": [1, 2],
+                  "secondary_mentor_id": 20
+                }
+                """, UpdateStudyRequest.class);
+
+        assertThat(request.getStudyName()).isEqualTo("기존 계약 스터디명");
+        assertThat(request.getLocation()).isEqualTo("공학관");
+        assertThat(request.getLocationDetail()).isEqualTo("301호");
+        assertThat(request.getStudyTagIds()).isEqualTo(List.of(1L, 2L));
+        assertThat(request.getSecondaryMentorId()).isEqualTo(20L);
+    }
+}

--- a/src/test/java/org/forif_backend/web/study/dto/UpdateStudyRequestTest.java
+++ b/src/test/java/org/forif_backend/web/study/dto/UpdateStudyRequestTest.java
@@ -30,5 +30,15 @@ class UpdateStudyRequestTest {
         assertThat(request.getLocationDetail()).isEqualTo("301호");
         assertThat(request.getStudyTagIds()).isEqualTo(List.of(1L, 2L));
         assertThat(request.getSecondaryMentorId()).isEqualTo(20L);
+        assertThat(request.isSecondaryMentorIdPresent()).isTrue();
+    }
+
+    @Test
+    void distinguishesExplicitSecondaryMentorRemovalFromAnOmittedField() throws Exception {
+        UpdateStudyRequest request = objectMapper.readValue(
+                "{\"secondary_mentor_id\": null}", UpdateStudyRequest.class);
+
+        assertThat(request.isSecondaryMentorIdPresent()).isTrue();
+        assertThat(request.getSecondaryMentorId()).isNull();
     }
 }


### PR DESCRIPTION
스터디 개설 신청 수정 API가 생성 요청 DTO를 재사용하지 않고
부분 수정 요청을 처리하도록 변경한다.

커리큘럼은 실제 변경된 경우에만 교체하고, 기존 계획 삭제 후 flush하여
주차 번호 unique constraint 충돌을 방지한다.