### PR TITLE
feat(admin): 스터디 기반 멘토 조회 지원

### DIFF
--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -194,8 +195,13 @@ public class StaffAccountService {
     ) {
         List<Long> userIds = page.content().stream().map(User::getId).toList();
         Map<Long, String> studyNames = studyRepository.findMentorStudyNamesByUserIds(userIds, year, semester);
+        Set<Long> manageableUserIds = staffAccountRepository.findMentorAccountUserIdsByUserIds(userIds);
         return page.withContent(page.content().stream()
-                .map(user -> MentorSummary.from(user, studyNames.get(user.getId())))
+                .map(user -> MentorSummary.from(
+                        user,
+                        studyNames.get(user.getId()),
+                        manageableUserIds.contains(user.getId())
+                ))
                 .toList());
     }
 

--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.forif_backend.application.auth.RefreshTokenService;
 import org.forif_backend.application.staff.dto.CreateAdminCommand;
 import org.forif_backend.application.staff.dto.CreateMentorCommand;
+import org.forif_backend.application.staff.dto.MentorSummary;
 import org.forif_backend.application.staff.dto.StaffSignInCommand;
 import org.forif_backend.application.staff.dto.StaffSignInResult;
 import org.forif_backend.common.auth.JwtProvider;
@@ -17,6 +18,7 @@ import org.forif_backend.common.util.DateUtils;
 import org.forif_backend.domain.staff.StaffAccount;
 import org.forif_backend.domain.staff.StaffAccountRepository;
 import org.forif_backend.domain.staff.StaffRole;
+import org.forif_backend.domain.study.StudyRepository;
 import org.forif_backend.domain.team.ForifTeam;
 import org.forif_backend.domain.team.ForifTeamRepository;
 import org.forif_backend.domain.user.User;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +41,7 @@ public class StaffAccountService {
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
     private final UserRepository userRepository;
+    private final StudyRepository studyRepository;
     private final ForifTeamRepository forifTeamRepository;
 
     /**
@@ -135,40 +139,64 @@ public class StaffAccountService {
      * 멘토 전체 목록 조회 (운영진 전용, 커서 페이지네이션)
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<StaffAccount> getMentors(Long cursor, Integer page, int size, String search) {
-        long totalElements = staffAccountRepository.count(search);
+    public CursorPageResponse<MentorSummary> getMentors(Long cursor, Integer page, int size, String search) {
+        long totalElements = studyRepository.countMentors(search);
 
         if (page != null) {
-            List<StaffAccount> staffAccounts = staffAccountRepository.searchMentorsWithOffset(page, size, search);
+            List<User> mentors = studyRepository.searchMentorsWithOffset(page, size, search);
             boolean hasNext = (long) (page + 1) * size < totalElements;
-            return CursorPageResponse.ofOffset(staffAccounts, hasNext, totalElements, page, size);
+            return toMentorPage(
+                    CursorPageResponse.ofOffset(mentors, hasNext, totalElements, page, size),
+                    null,
+                    null
+            );
         }
 
-        List<StaffAccount> staffAccounts = staffAccountRepository.searchWithCursor(cursor, size, search);
-        boolean hasNext = staffAccounts.size() > size;
-        List<StaffAccount> content = hasNext ? staffAccounts.subList(0, size) : staffAccounts;
-        Integer nextCursor = hasNext ? content.get(content.size() - 1).getUserId().intValue() : null;
-        return CursorPageResponse.ofCursor(content, nextCursor, hasNext, totalElements);
+        List<User> mentors = studyRepository.searchMentors(cursor, size, search);
+        boolean hasNext = mentors.size() > size;
+        List<User> content = hasNext ? mentors.subList(0, size) : mentors;
+        Integer nextCursor = hasNext ? content.get(content.size() - 1).getId().intValue() : null;
+        return toMentorPage(CursorPageResponse.ofCursor(content, nextCursor, hasNext, totalElements), null, null);
     }
 
     /**
      * 학기별 멘토 목록 조회 (운영진 전용, 커서/오프셋 페이지네이션)
      */
     @Transactional(readOnly = true)
-    public CursorPageResponse<StaffAccount> getMentors(int year, int semester, Long cursor, Integer page, int size, String search) {
-        long totalElements = staffAccountRepository.countMentorsByYearSemester(year, semester, search);
+    public CursorPageResponse<MentorSummary> getMentors(int year, int semester, Long cursor, Integer page, int size, String search) {
+        long totalElements = studyRepository.countMentorsByYearSemester(year, semester, search);
 
         if (page != null) {
-            List<StaffAccount> staffAccounts = staffAccountRepository.searchMentorsByYearSemesterWithOffset(year, semester, page, size, search);
+            List<User> mentors = studyRepository.searchMentorsByYearSemesterWithOffset(year, semester, page, size, search);
             boolean hasNext = (long) (page + 1) * size < totalElements;
-            return CursorPageResponse.ofOffset(staffAccounts, hasNext, totalElements, page, size);
+            return toMentorPage(
+                    CursorPageResponse.ofOffset(mentors, hasNext, totalElements, page, size),
+                    year,
+                    semester
+            );
         }
 
-        List<StaffAccount> staffAccounts = staffAccountRepository.searchMentorsByYearSemester(year, semester, cursor, size, search);
-        boolean hasNext = staffAccounts.size() > size;
-        List<StaffAccount> content = hasNext ? staffAccounts.subList(0, size) : staffAccounts;
-        Integer nextCursor = hasNext ? content.get(content.size() - 1).getUserId().intValue() : null;
-        return CursorPageResponse.ofCursor(content, nextCursor, hasNext, totalElements);
+        List<User> mentors = studyRepository.searchMentorsByYearSemester(year, semester, cursor, size, search);
+        boolean hasNext = mentors.size() > size;
+        List<User> content = hasNext ? mentors.subList(0, size) : mentors;
+        Integer nextCursor = hasNext ? content.get(content.size() - 1).getId().intValue() : null;
+        return toMentorPage(
+                CursorPageResponse.ofCursor(content, nextCursor, hasNext, totalElements),
+                year,
+                semester
+        );
+    }
+
+    private CursorPageResponse<MentorSummary> toMentorPage(
+            CursorPageResponse<User> page,
+            Integer year,
+            Integer semester
+    ) {
+        List<Long> userIds = page.content().stream().map(User::getId).toList();
+        Map<Long, String> studyNames = studyRepository.findMentorStudyNamesByUserIds(userIds, year, semester);
+        return page.withContent(page.content().stream()
+                .map(user -> MentorSummary.from(user, studyNames.get(user.getId())))
+                .toList());
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/staff/dto/MentorSummary.java
+++ b/src/main/java/org/forif_backend/application/staff/dto/MentorSummary.java
@@ -7,15 +7,17 @@ public record MentorSummary(
         String name,
         String department,
         String phoneNum,
-        String studyName
+        String studyName,
+        boolean manageable
 ) {
-    public static MentorSummary from(User user, String studyName) {
+    public static MentorSummary from(User user, String studyName, boolean manageable) {
         return new MentorSummary(
                 user.getId(),
                 user.getUserName(),
                 user.getDepartment(),
                 user.getPhoneNum(),
-                studyName
+                studyName,
+                manageable
         );
     }
 }

--- a/src/main/java/org/forif_backend/application/staff/dto/MentorSummary.java
+++ b/src/main/java/org/forif_backend/application/staff/dto/MentorSummary.java
@@ -1,0 +1,21 @@
+package org.forif_backend.application.staff.dto;
+
+import org.forif_backend.domain.user.User;
+
+public record MentorSummary(
+        Long userId,
+        String name,
+        String department,
+        String phoneNum,
+        String studyName
+) {
+    public static MentorSummary from(User user, String studyName) {
+        return new MentorSummary(
+                user.getId(),
+                user.getUserName(),
+                user.getDepartment(),
+                user.getPhoneNum(),
+                studyName
+        );
+    }
+}

--- a/src/main/java/org/forif_backend/domain/staff/StaffAccountRepository.java
+++ b/src/main/java/org/forif_backend/domain/staff/StaffAccountRepository.java
@@ -3,6 +3,7 @@ package org.forif_backend.domain.staff;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface StaffAccountRepository {
 
@@ -26,6 +27,8 @@ public interface StaffAccountRepository {
      * 여러 사용자의 StaffRole을 배치 조회 (역할이 둘이면 ADMIN 우선)
      */
     Map<Long, StaffRole> findStaffRolesByUserIds(List<Long> userIds);
+
+    Set<Long> findMentorAccountUserIdsByUserIds(List<Long> userIds);
 
     StaffAccount save(StaffAccount staffAccount);
 

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -3,6 +3,7 @@ package org.forif_backend.domain.study;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.forif_backend.domain.user.User;
 
 public interface StudyRepository {
     Optional<Study> findStudyById(Integer studyId);
@@ -17,6 +18,17 @@ public interface StudyRepository {
      * 여러 사용자의 현재 학기 스터디명을 배치 조회
      */
     Map<Long, String> findCurrentStudyNamesByUserIds(List<Long> userIds, int year, int semester);
+
+    /** 주·부멘토 관계를 기준으로 멘토별 스터디명을 배치 조회한다. */
+    Map<Long, String> findMentorStudyNamesByUserIds(List<Long> userIds, Integer year, Integer semester);
+
+    /** 주·부멘토 관계를 기준으로 멘토를 조회한다. */
+    List<User> searchMentors(Long cursor, int size, String search);
+    List<User> searchMentorsWithOffset(int page, int size, String search);
+    long countMentors(String search);
+    List<User> searchMentorsByYearSemester(int year, int semester, Long cursor, int size, String search);
+    List<User> searchMentorsByYearSemesterWithOffset(int year, int semester, int page, int size, String search);
+    long countMentorsByYearSemester(int year, int semester, String search);
 
     /**
      * 여러 사용자의 해당 학기 수강 스터디를 배치 조회

--- a/src/main/java/org/forif_backend/infrastructure/persistence/staff/StaffAccountJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/staff/StaffAccountJpaRepository.java
@@ -28,4 +28,7 @@ public interface StaffAccountJpaRepository extends JpaRepository<StaffAccount, L
             FROM StaffAccount sa WHERE sa.user.id = :userId AND sa.role = :role
             """)
     boolean existsByUserIdAndRole(@Param("userId") Long userId, @Param("role") StaffRole role);
+
+    @Query("SELECT sa.user.id FROM StaffAccount sa WHERE sa.user.id IN :userIds AND sa.role = :role")
+    List<Long> findUserIdsByUserIdInAndRole(@Param("userIds") List<Long> userIds, @Param("role") StaffRole role);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/staff/StaffAccountRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/staff/StaffAccountRepositoryImpl.java
@@ -10,6 +10,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -38,6 +39,14 @@ public class StaffAccountRepositoryImpl implements StaffAccountRepository {
     @Override
     public Map<Long, StaffRole> findStaffRolesByUserIds(List<Long> userIds) {
         return staffAccountQueryRepository.findStaffRolesByUserIds(userIds);
+    }
+
+    @Override
+    public Set<Long> findMentorAccountUserIdsByUserIds(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Set.of();
+        }
+        return Set.copyOf(staffAccountJpaRepository.findUserIdsByUserIdInAndRole(userIds, StaffRole.MENTOR));
     }
 
     @Override

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
@@ -7,9 +7,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.jpa.JPAExpressions;
 import jakarta.persistence.EntityManager;
 
 import org.forif_backend.domain.study.*;
+import org.forif_backend.domain.user.User;
 import org.forif_backend.domain.user.QUser;
 import org.springframework.stereotype.Repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,6 +25,7 @@ public class StudyQueryRepository {
     private final QStudyUser studyUser = QStudyUser.studyUser;
     private final QMentorStudy mentorStudy = QMentorStudy.mentorStudy;
     private final QUser secondaryMentor = new QUser("secondaryMentor");
+    private final QUser mentorUser = new QUser("mentorUser");
 
     public StudyQueryRepository(EntityManager em) {
         queryFactory = new JPAQueryFactory(em);
@@ -188,6 +191,162 @@ public class StudyQueryRepository {
                         t -> t.get(study.studyName),
                         (existing, replacement) -> existing
                 ));
+    }
+
+    public Map<Long, String> findMentorStudyNamesByUserIds(
+            List<Long> userIds,
+            Integer year,
+            Integer semester
+    ) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, Set<String>> studyNamesByMentorId = new java.util.LinkedHashMap<>();
+        collectMentorStudyNames(
+                study.primaryMentor.id,
+                userIds,
+                year,
+                semester,
+                studyNamesByMentorId
+        );
+        collectMentorStudyNames(
+                study.secondaryMentor.id,
+                userIds,
+                year,
+                semester,
+                studyNamesByMentorId
+        );
+
+        return studyNamesByMentorId.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> String.join(", ", entry.getValue())
+                ));
+    }
+
+    public List<User> searchMentors(Long cursor, int size, String search) {
+        return queryFactory
+                .selectFrom(mentorUser)
+                .where(
+                        mentorStudyExists(null, null),
+                        mentorCursorLt(cursor),
+                        mentorSearchKeyword(search)
+                )
+                .orderBy(mentorUser.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    public List<User> searchMentorsWithOffset(int page, int size, String search) {
+        return queryFactory
+                .selectFrom(mentorUser)
+                .where(mentorStudyExists(null, null), mentorSearchKeyword(search))
+                .orderBy(mentorUser.id.desc())
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+    }
+
+    public long countMentors(String search) {
+        Long count = queryFactory
+                .select(mentorUser.count())
+                .from(mentorUser)
+                .where(mentorStudyExists(null, null), mentorSearchKeyword(search))
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    public List<User> searchMentorsByYearSemester(
+            int year,
+            int semester,
+            Long cursor,
+            int size,
+            String search
+    ) {
+        return queryFactory
+                .selectFrom(mentorUser)
+                .where(
+                        mentorStudyExists(year, semester),
+                        mentorCursorLt(cursor),
+                        mentorSearchKeyword(search)
+                )
+                .orderBy(mentorUser.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    public List<User> searchMentorsByYearSemesterWithOffset(
+            int year,
+            int semester,
+            int page,
+            int size,
+            String search
+    ) {
+        return queryFactory
+                .selectFrom(mentorUser)
+                .where(mentorStudyExists(year, semester), mentorSearchKeyword(search))
+                .orderBy(mentorUser.id.desc())
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+    }
+
+    public long countMentorsByYearSemester(int year, int semester, String search) {
+        Long count = queryFactory
+                .select(mentorUser.count())
+                .from(mentorUser)
+                .where(mentorStudyExists(year, semester), mentorSearchKeyword(search))
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private void collectMentorStudyNames(
+            com.querydsl.core.types.dsl.NumberPath<Long> mentorId,
+            List<Long> userIds,
+            Integer year,
+            Integer semester,
+            Map<Long, Set<String>> studyNamesByMentorId
+    ) {
+        queryFactory
+                .select(mentorId, study.studyName)
+                .from(study)
+                .where(mentorId.in(userIds), yearEq(year), semesterEq(semester))
+                .orderBy(study.studyName.asc())
+                .fetch()
+                .forEach(tuple -> {
+                    Long id = tuple.get(mentorId);
+                    String name = tuple.get(study.studyName);
+                    if (id != null && name != null) {
+                        studyNamesByMentorId
+                                .computeIfAbsent(id, ignored -> new java.util.LinkedHashSet<>())
+                                .add(name);
+                    }
+                });
+    }
+
+    private BooleanExpression mentorStudyExists(Integer year, Integer semester) {
+        return JPAExpressions
+                .selectOne()
+                .from(study)
+                .where(
+                        yearEq(year),
+                        semesterEq(semester),
+                        study.primaryMentor.id.eq(mentorUser.id)
+                                .or(study.secondaryMentor.id.eq(mentorUser.id))
+                )
+                .exists();
+    }
+
+    private BooleanExpression mentorCursorLt(Long cursor) {
+        return cursor == null ? null : mentorUser.id.lt(cursor);
+    }
+
+    private BooleanExpression mentorSearchKeyword(String search) {
+        if (search == null || search.isBlank()) {
+            return null;
+        }
+        return mentorUser.userName.containsIgnoreCase(search);
     }
 
     public Map<Long, List<Study>> findCurrentStudiesByUserIds(List<Long> userIds, int year, int semester) {

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
@@ -26,6 +26,7 @@ public class StudyQueryRepository {
     private final QMentorStudy mentorStudy = QMentorStudy.mentorStudy;
     private final QUser secondaryMentor = new QUser("secondaryMentor");
     private final QUser mentorUser = new QUser("mentorUser");
+    private final QStudy mentorSearchStudy = new QStudy("mentorSearchStudy");
 
     public StudyQueryRepository(EntityManager em) {
         queryFactory = new JPAQueryFactory(em);
@@ -155,6 +156,7 @@ public class StudyQueryRepository {
                 .where(
                         study.actYear.eq(year),
                         study.actSemester.eq(semester),
+                        study.studyStatus.eq(StudyStatus.APPROVED),
                         study.primaryMentor.id.in(userIds).or(study.secondaryMentor.id.in(userIds))
                 )
                 .fetch();
@@ -231,7 +233,7 @@ public class StudyQueryRepository {
                 .where(
                         mentorStudyExists(null, null),
                         mentorCursorLt(cursor),
-                        mentorSearchKeyword(search)
+                        mentorSearchKeyword(search, null, null)
                 )
                 .orderBy(mentorUser.id.desc())
                 .limit(size + 1)
@@ -241,7 +243,7 @@ public class StudyQueryRepository {
     public List<User> searchMentorsWithOffset(int page, int size, String search) {
         return queryFactory
                 .selectFrom(mentorUser)
-                .where(mentorStudyExists(null, null), mentorSearchKeyword(search))
+                .where(mentorStudyExists(null, null), mentorSearchKeyword(search, null, null))
                 .orderBy(mentorUser.id.desc())
                 .offset((long) page * size)
                 .limit(size)
@@ -252,7 +254,7 @@ public class StudyQueryRepository {
         Long count = queryFactory
                 .select(mentorUser.count())
                 .from(mentorUser)
-                .where(mentorStudyExists(null, null), mentorSearchKeyword(search))
+                .where(mentorStudyExists(null, null), mentorSearchKeyword(search, null, null))
                 .fetchOne();
         return count != null ? count : 0L;
     }
@@ -269,7 +271,7 @@ public class StudyQueryRepository {
                 .where(
                         mentorStudyExists(year, semester),
                         mentorCursorLt(cursor),
-                        mentorSearchKeyword(search)
+                        mentorSearchKeyword(search, year, semester)
                 )
                 .orderBy(mentorUser.id.desc())
                 .limit(size + 1)
@@ -285,7 +287,7 @@ public class StudyQueryRepository {
     ) {
         return queryFactory
                 .selectFrom(mentorUser)
-                .where(mentorStudyExists(year, semester), mentorSearchKeyword(search))
+                .where(mentorStudyExists(year, semester), mentorSearchKeyword(search, year, semester))
                 .orderBy(mentorUser.id.desc())
                 .offset((long) page * size)
                 .limit(size)
@@ -296,7 +298,7 @@ public class StudyQueryRepository {
         Long count = queryFactory
                 .select(mentorUser.count())
                 .from(mentorUser)
-                .where(mentorStudyExists(year, semester), mentorSearchKeyword(search))
+                .where(mentorStudyExists(year, semester), mentorSearchKeyword(search, year, semester))
                 .fetchOne();
         return count != null ? count : 0L;
     }
@@ -311,7 +313,12 @@ public class StudyQueryRepository {
         queryFactory
                 .select(mentorId, study.studyName)
                 .from(study)
-                .where(mentorId.in(userIds), yearEq(year), semesterEq(semester))
+                .where(
+                        mentorId.in(userIds),
+                        yearEq(year),
+                        semesterEq(semester),
+                        study.studyStatus.eq(StudyStatus.APPROVED)
+                )
                 .orderBy(study.studyName.asc())
                 .fetch()
                 .forEach(tuple -> {
@@ -332,6 +339,7 @@ public class StudyQueryRepository {
                 .where(
                         yearEq(year),
                         semesterEq(semester),
+                        study.studyStatus.eq(StudyStatus.APPROVED),
                         study.primaryMentor.id.eq(mentorUser.id)
                                 .or(study.secondaryMentor.id.eq(mentorUser.id))
                 )
@@ -342,11 +350,23 @@ public class StudyQueryRepository {
         return cursor == null ? null : mentorUser.id.lt(cursor);
     }
 
-    private BooleanExpression mentorSearchKeyword(String search) {
+    private BooleanExpression mentorSearchKeyword(String search, Integer year, Integer semester) {
         if (search == null || search.isBlank()) {
             return null;
         }
-        return mentorUser.userName.containsIgnoreCase(search);
+        return mentorUser.userName.containsIgnoreCase(search)
+                .or(JPAExpressions
+                        .selectOne()
+                        .from(mentorSearchStudy)
+                        .where(
+                                year == null ? null : mentorSearchStudy.actYear.eq(year),
+                                semester == null ? null : mentorSearchStudy.actSemester.eq(semester),
+                                mentorSearchStudy.studyStatus.eq(StudyStatus.APPROVED),
+                                mentorSearchStudy.studyName.containsIgnoreCase(search),
+                                mentorSearchStudy.primaryMentor.id.eq(mentorUser.id)
+                                        .or(mentorSearchStudy.secondaryMentor.id.eq(mentorUser.id))
+                        )
+                        .exists());
     }
 
     public Map<Long, List<Study>> findCurrentStudiesByUserIds(List<Long> userIds, int year, int semester) {

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.forif_backend.domain.study.*;
 import org.forif_backend.domain.study.Study;
 import org.forif_backend.domain.study.StudyRepository;
 import org.forif_backend.domain.study.StudySearchCond;
+import org.forif_backend.domain.user.User;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -60,6 +61,57 @@ public class StudyRepositoryImpl implements StudyRepository {
     @Override
     public Map<Long, String> findCurrentStudyNamesByUserIds(List<Long> userIds, int year, int semester) {
         return studyQueryRepository.findCurrentStudyNamesByUserIds(userIds, year, semester);
+    }
+
+    @Override
+    public Map<Long, String> findMentorStudyNamesByUserIds(
+            List<Long> userIds,
+            Integer year,
+            Integer semester
+    ) {
+        return studyQueryRepository.findMentorStudyNamesByUserIds(userIds, year, semester);
+    }
+
+    @Override
+    public List<User> searchMentors(Long cursor, int size, String search) {
+        return studyQueryRepository.searchMentors(cursor, size, search);
+    }
+
+    @Override
+    public List<User> searchMentorsWithOffset(int page, int size, String search) {
+        return studyQueryRepository.searchMentorsWithOffset(page, size, search);
+    }
+
+    @Override
+    public long countMentors(String search) {
+        return studyQueryRepository.countMentors(search);
+    }
+
+    @Override
+    public List<User> searchMentorsByYearSemester(
+            int year,
+            int semester,
+            Long cursor,
+            int size,
+            String search
+    ) {
+        return studyQueryRepository.searchMentorsByYearSemester(year, semester, cursor, size, search);
+    }
+
+    @Override
+    public List<User> searchMentorsByYearSemesterWithOffset(
+            int year,
+            int semester,
+            int page,
+            int size,
+            String search
+    ) {
+        return studyQueryRepository.searchMentorsByYearSemesterWithOffset(year, semester, page, size, search);
+    }
+
+    @Override
+    public long countMentorsByYearSemester(int year, int semester, String search) {
+        return studyQueryRepository.countMentorsByYearSemester(year, semester, search);
     }
 
     @Override

--- a/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
+++ b/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
@@ -178,6 +178,7 @@ public class StaffAccountController {
             - cursor: 커서 기반 페이지네이션 (무한 스크롤). next_cursor 값을 다음 요청의 cursor로 전달.
             - page: 오프셋 기반 페이지네이션 (0부터 시작). cursor와 함께 사용 불가.
             둘 다 생략 시 cursor 모드로 첫 페이지를 반환합니다.
+            - manageable: 기존 멘토 계정이 있어 수정·삭제 API를 사용할 수 있는지 여부입니다.
             """)
     @GetMapping("/api/v1/admin/mentors")
     @PreAuthorize("hasRole('ADMIN')")
@@ -185,7 +186,7 @@ public class StaffAccountController {
             @Parameter(description = "이전 페이지의 마지막 멘토 ID (cursor 모드)") @RequestParam(required = false) Long cursor,
             @Parameter(description = "페이지 번호, 0부터 시작 (offset 모드, cursor와 함께 사용 불가)") @RequestParam(required = false) Integer page,
             @Parameter(description = "페이지 당 항목 수") @RequestParam(defaultValue = "20") int size,
-            @Parameter(description = "이름 검색어") @RequestParam(required = false) String search
+            @Parameter(description = "멘토 이름 또는 스터디 이름 검색어") @RequestParam(required = false) String search
     ) {
         CursorPageResponse<MentorSummary> result = staffAccountService.getMentors(cursor, page, size, search);
 
@@ -204,6 +205,7 @@ public class StaffAccountController {
             - cursor: 커서 기반 페이지네이션 (무한 스크롤). next_cursor 값을 다음 요청의 cursor로 전달.
             - page: 오프셋 기반 페이지네이션 (0부터 시작). cursor와 함께 사용 불가.
             둘 다 생략 시 cursor 모드로 첫 페이지를 반환합니다.
+            - manageable: 기존 멘토 계정이 있어 수정·삭제 API를 사용할 수 있는지 여부입니다.
             """)
     @GetMapping("/api/v1/admin/mentors/{year}/{semester}")
     @PreAuthorize("hasRole('ADMIN')")
@@ -213,7 +215,7 @@ public class StaffAccountController {
             @Parameter(description = "이전 페이지의 마지막 멘토 ID (cursor 모드)") @RequestParam(required = false) Long cursor,
             @Parameter(description = "페이지 번호, 0부터 시작 (offset 모드, cursor와 함께 사용 불가)") @RequestParam(required = false) Integer page,
             @Parameter(description = "페이지 당 항목 수") @RequestParam(defaultValue = "20") int size,
-            @Parameter(description = "이름 검색어") @RequestParam(required = false) String search
+            @Parameter(description = "멘토 이름 또는 스터디 이름 검색어") @RequestParam(required = false) String search
     ) {
         CursorPageResponse<MentorSummary> result = staffAccountService.getMentors(year, semester, cursor, page, size, search);
 

--- a/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
+++ b/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
@@ -11,6 +11,7 @@ import org.forif_backend.application.staff.StaffAccountService;
 import org.forif_backend.application.user.UserService;
 import org.forif_backend.application.staff.dto.CreateAdminCommand;
 import org.forif_backend.application.staff.dto.CreateMentorCommand;
+import org.forif_backend.application.staff.dto.MentorSummary;
 import org.forif_backend.application.staff.dto.StaffSignInCommand;
 import org.forif_backend.application.staff.dto.StaffSignInResult;
 import org.forif_backend.common.dto.response.ApiResponse;
@@ -186,7 +187,7 @@ public class StaffAccountController {
             @Parameter(description = "페이지 당 항목 수") @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "이름 검색어") @RequestParam(required = false) String search
     ) {
-        CursorPageResponse<StaffAccount> result = staffAccountService.getMentors(cursor, page, size, search);
+        CursorPageResponse<MentorSummary> result = staffAccountService.getMentors(cursor, page, size, search);
 
         List<MentorResponse> content = result.content().stream()
                 .map(MentorResponse::from)
@@ -214,7 +215,7 @@ public class StaffAccountController {
             @Parameter(description = "페이지 당 항목 수") @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "이름 검색어") @RequestParam(required = false) String search
     ) {
-        CursorPageResponse<StaffAccount> result = staffAccountService.getMentors(year, semester, cursor, page, size, search);
+        CursorPageResponse<MentorSummary> result = staffAccountService.getMentors(year, semester, cursor, page, size, search);
 
         List<MentorResponse> content = result.content().stream()
                 .map(MentorResponse::from)

--- a/src/main/java/org/forif_backend/web/staff/dto/MentorResponse.java
+++ b/src/main/java/org/forif_backend/web/staff/dto/MentorResponse.java
@@ -1,7 +1,7 @@
 package org.forif_backend.web.staff.dto;
 
 import lombok.Builder;
-import org.forif_backend.domain.staff.StaffAccount;
+import org.forif_backend.application.staff.dto.MentorSummary;
 
 @Builder
 public record MentorResponse(
@@ -11,13 +11,13 @@ public record MentorResponse(
     String phoneNum,
     String studyName
 ) {
-    public static MentorResponse from(StaffAccount staffAccount) {
+    public static MentorResponse from(MentorSummary mentor) {
         return MentorResponse.builder()
-                .userId(staffAccount.getUserId())
-                .name(staffAccount.getName())
-                .department(staffAccount.getUser().getDepartment())
-                .phoneNum(staffAccount.getUser().getPhoneNum())
-                .studyName(staffAccount.getAffiliation())
+                .userId(mentor.userId())
+                .name(mentor.name())
+                .department(mentor.department())
+                .phoneNum(mentor.phoneNum())
+                .studyName(mentor.studyName())
                 .build();
     }
 }

--- a/src/main/java/org/forif_backend/web/staff/dto/MentorResponse.java
+++ b/src/main/java/org/forif_backend/web/staff/dto/MentorResponse.java
@@ -9,7 +9,8 @@ public record MentorResponse(
     String name,
     String department,
     String phoneNum,
-    String studyName
+    String studyName,
+    boolean manageable
 ) {
     public static MentorResponse from(MentorSummary mentor) {
         return MentorResponse.builder()
@@ -18,6 +19,7 @@ public record MentorResponse(
                 .department(mentor.department())
                 .phoneNum(mentor.phoneNum())
                 .studyName(mentor.studyName())
+                .manageable(mentor.manageable())
                 .build();
     }
 }

--- a/src/test/java/org/forif_backend/application/staff/StaffAccountServiceMentorQueryTest.java
+++ b/src/test/java/org/forif_backend/application/staff/StaffAccountServiceMentorQueryTest.java
@@ -1,0 +1,56 @@
+package org.forif_backend.application.staff;
+
+import org.forif_backend.application.auth.RefreshTokenService;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.staff.dto.MentorSummary;
+import org.forif_backend.common.auth.JwtProvider;
+import org.forif_backend.common.dto.response.CursorPageResponse;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.team.ForifTeamRepository;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StaffAccountServiceMentorQueryTest {
+
+    @Mock private SemesterService semesterService;
+    @Mock private StaffAccountRepository staffAccountRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private UserRepository userRepository;
+    @Mock private ForifTeamRepository forifTeamRepository;
+    @Mock private StudyRepository studyRepository;
+    @InjectMocks private StaffAccountService staffAccountService;
+
+    @Test
+    void marksOnlyLegacyMentorAccountsAsManageable() {
+        User manageableMentor = User.createUser(1L, "기존 멘토", "legacy@forif.org", "010", "컴퓨터공학과");
+        User studyOnlyMentor = User.createUser(2L, "신규 멘토", "study@forif.org", "010", "컴퓨터공학과");
+        when(studyRepository.countMentors(null)).thenReturn(2L);
+        when(studyRepository.searchMentors(null, 20, null)).thenReturn(List.of(manageableMentor, studyOnlyMentor));
+        when(studyRepository.findMentorStudyNamesByUserIds(List.of(1L, 2L), null, null))
+                .thenReturn(Map.of(1L, "기존 스터디", 2L, "신규 스터디"));
+        when(staffAccountRepository.findMentorAccountUserIdsByUserIds(List.of(1L, 2L)))
+                .thenReturn(Set.of(1L));
+
+        CursorPageResponse<MentorSummary> result = staffAccountService.getMentors(null, null, 20, null);
+
+        assertThat(result.content()).extracting(MentorSummary::manageable)
+                .containsExactly(true, false);
+    }
+}

--- a/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepositoryMentorTest.java
+++ b/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepositoryMentorTest.java
@@ -1,0 +1,113 @@
+package org.forif_backend.infrastructure.persistence.study;
+
+import jakarta.persistence.EntityManager;
+import org.forif_backend.common.config.JpaAuditingConfig;
+import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.user.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, StudyQueryRepository.class})
+class StudyQueryRepositoryMentorTest {
+
+    private static final int YEAR = 2026;
+    private static final int SEMESTER = 1;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private StudyQueryRepository studyQueryRepository;
+
+    @Test
+    void returnsOnlyApprovedMentorsAndSupportsStudyNameSearch() {
+        User approvedMentor = persistUser(900001L, "승인 멘토");
+        User pendingMentor = persistUser(900002L, "대기 멘토");
+        User rejectedSecondaryMentor = persistUser(900003L, "반려 부멘토");
+
+        persistApprovedStudy(approvedMentor, "운영체제 심화 스터디");
+        persistPendingStudy(pendingMentor, "운영체제 대기 스터디");
+        persistRejectedStudy(pendingMentor, rejectedSecondaryMentor, "운영체제 반려 스터디");
+        entityManager.flush();
+        entityManager.clear();
+
+        List<User> mentors = studyQueryRepository.searchMentors(null, 20, "운영체제");
+        List<User> offsetMentors = studyQueryRepository.searchMentorsWithOffset(0, 20, "운영체제");
+        long mentorCount = studyQueryRepository.countMentors("운영체제");
+        List<User> semesterMentors = studyQueryRepository.searchMentorsByYearSemester(
+                YEAR,
+                SEMESTER,
+                null,
+                20,
+                "운영체제"
+        );
+        List<User> semesterOffsetMentors = studyQueryRepository.searchMentorsByYearSemesterWithOffset(
+                YEAR,
+                SEMESTER,
+                0,
+                20,
+                "운영체제"
+        );
+        long semesterMentorCount = studyQueryRepository.countMentorsByYearSemester(
+                YEAR,
+                SEMESTER,
+                "운영체제"
+        );
+        Set<Long> mentorIds = studyQueryRepository.findMentorUserIdsByUserIds(
+                List.of(approvedMentor.getId(), pendingMentor.getId(), rejectedSecondaryMentor.getId()),
+                YEAR,
+                SEMESTER
+        );
+        Map<Long, String> studyNames = studyQueryRepository.findMentorStudyNamesByUserIds(
+                List.of(approvedMentor.getId(), pendingMentor.getId(), rejectedSecondaryMentor.getId()),
+                YEAR,
+                SEMESTER
+        );
+
+        assertThat(mentors).extracting(User::getId).containsExactly(approvedMentor.getId());
+        assertThat(offsetMentors).extracting(User::getId).containsExactly(approvedMentor.getId());
+        assertThat(mentorCount).isEqualTo(1);
+        assertThat(semesterMentors).extracting(User::getId).containsExactly(approvedMentor.getId());
+        assertThat(semesterOffsetMentors).extracting(User::getId).containsExactly(approvedMentor.getId());
+        assertThat(semesterMentorCount).isEqualTo(1);
+        assertThat(mentorIds).containsExactly(approvedMentor.getId());
+        assertThat(studyNames).containsExactly(Map.entry(approvedMentor.getId(), "운영체제 심화 스터디"));
+    }
+
+    private User persistUser(Long id, String name) {
+        User user = User.createUser(id, name, id + "@forif.org", "010-0000-0000", "컴퓨터공학과");
+        entityManager.persist(user);
+        return user;
+    }
+
+    private void persistApprovedStudy(User mentor, String name) {
+        Study study = Study.createPendingStudy(mentor, YEAR, SEMESTER);
+        study.setStudyName(name);
+        study.approve();
+        entityManager.persist(study);
+    }
+
+    private void persistPendingStudy(User mentor, String name) {
+        Study study = Study.createPendingStudy(mentor, YEAR, SEMESTER);
+        study.setStudyName(name);
+        entityManager.persist(study);
+    }
+
+    private void persistRejectedStudy(User primaryMentor, User secondaryMentor, String name) {
+        Study study = Study.createPendingStudy(primaryMentor, YEAR, SEMESTER);
+        study.setStudyName(name);
+        study.setSecondaryMentor(secondaryMentor);
+        study.setSecondaryMentorName(secondaryMentor.getUserName());
+        study.reject("반려 사유");
+        entityManager.persist(study);
+    }
+}


### PR DESCRIPTION
- 스터디의 주·보조 멘토 관계를 기준으로 멘토 목록과 수를 조회하도록 변경
- 멘토별 스터디명을 함께 반환하도록 조회 DTO 추가
- 기존 관리자 멘토 목록 API 응답 형식 유지