### PR TITLE
feat(staff): 운영진 비밀번호 변경 및 정책 검증 추가

### DIFF
--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -15,6 +15,7 @@ import org.forif_backend.application.semester.dto.SemesterInfo;
 import org.forif_backend.common.exception.ErrorCode;
 import org.forif_backend.common.exception.ForifException;
 import org.forif_backend.common.util.DateUtils;
+import org.forif_backend.common.util.PasswordUtils;
 import org.forif_backend.domain.staff.StaffAccount;
 import org.forif_backend.domain.staff.StaffAccountRepository;
 import org.forif_backend.domain.staff.StaffRole;
@@ -84,6 +85,24 @@ public class StaffAccountService {
         );
     }
 
+    /** 현재 로그인한 운영진의 비밀번호를 변경하고 기존 ADMIN 세션을 무효화한다. */
+    @Transactional
+    public void changeAdminPassword(Long userId, String currentPassword, String newPassword) {
+        StaffAccount staffAccount = staffAccountRepository.findByUserIdAndRole(userId, StaffRole.ADMIN)
+                .orElseThrow(() -> new ForifException(ErrorCode.STAFF_NOT_FOUND));
+
+        if (!passwordEncoder.matches(currentPassword, staffAccount.getPassword())) {
+            throw new ForifException(ErrorCode.PASSWORD_MISMATCH);
+        }
+        if (passwordEncoder.matches(newPassword, staffAccount.getPassword())) {
+            throw new ForifException(ErrorCode.INVALID_INPUT);
+        }
+        PasswordUtils.validate(newPassword);
+
+        staffAccount.updatePassword(passwordEncoder.encode(newPassword));
+        refreshTokenService.deleteRefreshToken(userId.toString(), StaffRole.ADMIN.getValue());
+    }
+
     /**
      * 멘토 계정 생성 (운영진 전용)
      */
@@ -92,6 +111,7 @@ public class StaffAccountService {
         if (staffAccountRepository.existsByUserIdAndRole(command.userId(), StaffRole.MENTOR)) {
             throw new ForifException(ErrorCode.STAFF_ALREADY_EXISTS);
         }
+        PasswordUtils.validate(command.password());
 
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
@@ -121,6 +141,9 @@ public class StaffAccountService {
             staffAccount.getUser().updateUserName(name);
         }
 
+        if (password != null) {
+            PasswordUtils.validate(password);
+        }
         String encodedPassword = password != null ? passwordEncoder.encode(password) : null;
         staffAccount.updateInfo(name, encodedPassword, affiliation);
     }
@@ -296,6 +319,7 @@ public class StaffAccountService {
         if (staffAccountRepository.existsByUserIdAndRole(command.userId(), StaffRole.ADMIN)) {
             throw new ForifException(ErrorCode.STAFF_ALREADY_EXISTS);
         }
+        PasswordUtils.validate(command.password());
 
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
@@ -361,6 +385,7 @@ public class StaffAccountService {
             staffAccount.updateName(name);
         }
         if (password != null) {
+            PasswordUtils.validate(password);
             staffAccount.updatePassword(passwordEncoder.encode(password));
         }
         if (affiliation != null) {

--- a/src/main/java/org/forif_backend/common/util/PasswordUtils.java
+++ b/src/main/java/org/forif_backend/common/util/PasswordUtils.java
@@ -1,0 +1,30 @@
+package org.forif_backend.common.util;
+
+import lombok.experimental.UtilityClass;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+
+@UtilityClass
+public class PasswordUtils {
+
+    private static final String SPECIAL_CHARACTERS = "!@#$%^&*(),.?\":{}|<>";
+
+    public static void validate(String password) {
+        if (!isValid(password)) {
+            throw new ForifException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    public static boolean isValid(String password) {
+        if (password == null || password.length() < 8 || password.length() > 20) {
+            return false;
+        }
+
+        int categoryCount = 0;
+        if (password.matches(".*[A-Z].*")) categoryCount++;
+        if (password.matches(".*[a-z].*")) categoryCount++;
+        if (password.matches(".*[0-9].*")) categoryCount++;
+        if (password.chars().anyMatch(ch -> SPECIAL_CHARACTERS.indexOf(ch) >= 0)) categoryCount++;
+        return categoryCount >= 2;
+    }
+}

--- a/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
+++ b/src/main/java/org/forif_backend/web/staff/StaffAccountController.java
@@ -77,6 +77,17 @@ public class StaffAccountController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "내 운영진 비밀번호 변경", description = "현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다. 변경 후 이 계정의 운영진 세션이 만료되어 다시 로그인해야 합니다.")
+    @PatchMapping("/api/v1/staff/me/password")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> changeAdminPassword(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid ChangeAdminPasswordRequest request
+    ) {
+        staffAccountService.changeAdminPassword(userId, request.currentPassword(), request.newPassword());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
     // ==================== 회장단 운영진 관리 API ====================
 
     /**

--- a/src/main/java/org/forif_backend/web/staff/dto/ChangeAdminPasswordRequest.java
+++ b/src/main/java/org/forif_backend/web/staff/dto/ChangeAdminPasswordRequest.java
@@ -1,0 +1,10 @@
+package org.forif_backend.web.staff.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangeAdminPasswordRequest(
+        @JsonProperty("current_password") @NotBlank String currentPassword,
+        @JsonProperty("new_password") @NotBlank @Size(min = 8, max = 20) String newPassword
+) {}

--- a/src/test/java/org/forif_backend/application/staff/StaffAccountServicePasswordChangeTest.java
+++ b/src/test/java/org/forif_backend/application/staff/StaffAccountServicePasswordChangeTest.java
@@ -1,0 +1,112 @@
+package org.forif_backend.application.staff;
+
+import org.forif_backend.application.auth.RefreshTokenService;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.staff.dto.CreateAdminCommand;
+import org.forif_backend.common.auth.JwtProvider;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.staff.StaffAccount;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.staff.StaffRole;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.team.ForifTeamRepository;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StaffAccountServicePasswordChangeTest {
+
+    private static final Long USER_ID = 20260001L;
+    private static final String CURRENT_PASSWORD = "Current12!";
+    private static final String NEW_PASSWORD = "NewPassword1!";
+
+    @Mock private SemesterService semesterService;
+    @Mock private StaffAccountRepository staffAccountRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private UserRepository userRepository;
+    @Mock private StudyRepository studyRepository;
+    @Mock private ForifTeamRepository forifTeamRepository;
+    @InjectMocks private StaffAccountService staffAccountService;
+
+    @Test
+    void changesPasswordAfterVerifyingCurrentPasswordAndInvalidatesAdminRefreshToken() {
+        StaffAccount account = adminAccount("encoded-current-password");
+        when(staffAccountRepository.findByUserIdAndRole(USER_ID, StaffRole.ADMIN)).thenReturn(Optional.of(account));
+        when(passwordEncoder.matches(CURRENT_PASSWORD, "encoded-current-password")).thenReturn(true);
+        when(passwordEncoder.matches(NEW_PASSWORD, "encoded-current-password")).thenReturn(false);
+        when(passwordEncoder.encode(NEW_PASSWORD)).thenReturn("encoded-new-password");
+
+        staffAccountService.changeAdminPassword(USER_ID, CURRENT_PASSWORD, NEW_PASSWORD);
+
+        assertThat(account.getPassword()).isEqualTo("encoded-new-password");
+        verify(refreshTokenService).deleteRefreshToken(USER_ID.toString(), StaffRole.ADMIN.getValue());
+    }
+
+    @Test
+    void rejectsPasswordChangeWhenCurrentPasswordDoesNotMatch() {
+        StaffAccount account = adminAccount("encoded-current-password");
+        when(staffAccountRepository.findByUserIdAndRole(USER_ID, StaffRole.ADMIN)).thenReturn(Optional.of(account));
+        when(passwordEncoder.matches(CURRENT_PASSWORD, "encoded-current-password")).thenReturn(false);
+
+        assertThatThrownBy(() -> staffAccountService.changeAdminPassword(USER_ID, CURRENT_PASSWORD, NEW_PASSWORD))
+                .isInstanceOf(ForifException.class)
+                .extracting(exception -> ((ForifException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.PASSWORD_MISMATCH);
+
+        verify(passwordEncoder, never()).encode(NEW_PASSWORD);
+        verify(refreshTokenService, never()).deleteRefreshToken(USER_ID.toString(), StaffRole.ADMIN.getValue());
+    }
+
+    @Test
+    void rejectsNewPasswordThatDoesNotMeetPasswordPolicy() {
+        StaffAccount account = adminAccount("encoded-current-password");
+        when(staffAccountRepository.findByUserIdAndRole(USER_ID, StaffRole.ADMIN)).thenReturn(Optional.of(account));
+        when(passwordEncoder.matches(CURRENT_PASSWORD, "encoded-current-password")).thenReturn(true);
+
+        assertThatThrownBy(() -> staffAccountService.changeAdminPassword(USER_ID, CURRENT_PASSWORD, "short1!"))
+                .isInstanceOf(ForifException.class)
+                .extracting(exception -> ((ForifException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        verify(passwordEncoder, never()).encode("short1!");
+        verify(refreshTokenService, never()).deleteRefreshToken(USER_ID.toString(), StaffRole.ADMIN.getValue());
+    }
+
+    @Test
+    void rejectsInvalidPasswordBeforeCreatingAdminAccount() {
+        StaffAccount requester = adminAccount("encoded-requester-password");
+        when(staffAccountRepository.findByUserIdAndRole(USER_ID, StaffRole.ADMIN)).thenReturn(Optional.of(requester));
+        when(staffAccountRepository.existsByUserIdAndRole(20260002L, StaffRole.ADMIN)).thenReturn(false);
+
+        assertThatThrownBy(() -> staffAccountService.createAdmin(
+                USER_ID,
+                new CreateAdminCommand(20260002L, "onlylowercase", "기획팀")
+        )).isInstanceOf(ForifException.class)
+                .extracting(exception -> ((ForifException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        verify(userRepository, never()).findById(20260002L);
+    }
+
+    private StaffAccount adminAccount(String password) {
+        User user = User.createUser(USER_ID, "운영진", "admin@hanyang.ac.kr", "010-0000-0000", "컴퓨터학부");
+        return StaffAccount.createStaffAccount(user, password, "운영진", StaffRole.ADMIN, "회장");
+    }
+}

--- a/src/test/java/org/forif_backend/common/util/PasswordUtilsTest.java
+++ b/src/test/java/org/forif_backend/common/util/PasswordUtilsTest.java
@@ -1,0 +1,33 @@
+package org.forif_backend.common.util;
+
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PasswordUtilsTest {
+
+    @Test
+    void acceptsPasswordWithAtLeastTwoCharacterCategories() {
+        assertThatCode(() -> PasswordUtils.validate("Password1!"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsPasswordOutsideTheSharedPolicy() {
+        assertThatThrownBy(() -> PasswordUtils.validate("onlylowercase"))
+                .isInstanceOf(ForifException.class)
+                .extracting(exception -> ((ForifException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    void onlyCountsTheSameAsciiCharacterCategoriesAsTheFrontendPolicy() {
+        assertThatThrownBy(() -> PasswordUtils.validate("가나다라마바사123"))
+                .isInstanceOf(ForifException.class)
+                .extracting(exception -> ((ForifException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+}


### PR DESCRIPTION
- 현재 비밀번호 검증 기반의 운영진 비밀번호 변경 API 추가
- BCrypt 해싱 후 저장 및 ADMIN refresh token 무효화
- 공용 PasswordUtils로 운영진·멘토 생성/수정/변경 정책 통일
- 비밀번호 정책 및 계정 변경 회귀 테스트 추가