### PR TITLE
feat(products): 서비스 신청 썸네일 업로드 지원

### DIFF
--- a/src/main/java/org/forif_backend/application/product/ProductService.java
+++ b/src/main/java/org/forif_backend/application/product/ProductService.java
@@ -60,7 +60,7 @@ public class ProductService {
 
     /** 서비스 등록 신청 (부원) */
     @Transactional
-    public ProductInfo applyProduct(Long userId, CreateProductApplicationCommand command) {
+    public ProductInfo applyProduct(Long userId, CreateProductApplicationCommand command, MultipartFile thumbnail) {
         User applicant = userRepository.findUserById(userId)
                 .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
 
@@ -82,6 +82,11 @@ public class ProductService {
                 applicant
         );
         product.addMember(ProductMember.create(product, applicant.getUserName(), "신청자"));
+
+        if (thumbnail != null && !thumbnail.isEmpty()) {
+            validateImageFile(thumbnail);
+            product.updateThumbnail(filePort.uploadFile(thumbnail, THUMBNAIL_DIRECTORY));
+        }
 
         try {
             return toInfo(productRepository.save(product));

--- a/src/main/java/org/forif_backend/web/product/ProductController.java
+++ b/src/main/java/org/forif_backend/web/product/ProductController.java
@@ -13,8 +13,10 @@ import org.forif_backend.web.product.dto.ProductApplicationResponse;
 import org.forif_backend.web.product.dto.ProductDetailResponse;
 import org.forif_backend.web.product.dto.ProductResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -42,13 +44,14 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.fromList(applications)));
     }
 
-    @Operation(summary = "서비스 등록 신청", description = "부원이 직접 만든 서비스의 등록을 신청합니다. 운영진 승인 후 목록에 게시됩니다.")
-    @PostMapping("/applications")
+    @Operation(summary = "서비스 등록 신청", description = "부원이 직접 만든 서비스의 등록을 신청합니다. request(JSON)와 선택 썸네일 이미지 파일을 multipart/form-data로 전송합니다. 운영진 승인 후 목록에 게시됩니다.")
+    @PostMapping(value = "/applications", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ProductApplicationResponse>> applyProduct(
             @AuthenticationPrincipal Long userId,
-            @Valid @RequestBody CreateProductApplicationRequest request
+            @Valid @RequestPart("request") CreateProductApplicationRequest request,
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail
     ) {
-        ProductInfo info = productService.applyProduct(userId, request.toCommand());
+        ProductInfo info = productService.applyProduct(userId, request.toCommand(), thumbnail);
         return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.from(info)));
     }
 

--- a/src/main/java/org/forif_backend/web/product/dto/ProductApplicationResponse.java
+++ b/src/main/java/org/forif_backend/web/product/dto/ProductApplicationResponse.java
@@ -15,6 +15,7 @@ public record ProductApplicationResponse(
         String sourceType,
         String serviceUrl,
         String githubUrl,
+        String thumbnailUrl,
         List<String> techStack,
         String status,
         String rejectReason,
@@ -30,6 +31,7 @@ public record ProductApplicationResponse(
                 .sourceType(info.sourceType())
                 .serviceUrl(info.serviceUrl())
                 .githubUrl(info.githubUrl())
+                .thumbnailUrl(info.thumbnailUrl())
                 .techStack(info.techStack())
                 .status(toApplicationStatus(info.status()))
                 .rejectReason(info.rejectReason())


### PR DESCRIPTION
- 서비스 등록 신청 API에 multipart 썸네일 업로드 추가
- 신청 썸네일을 서비스 이미지 저장소에 보관
- 서비스 신청내역 응답에 썸네일 URL 포함