### PR TITLE
fix(staff,products): 비밀번호 재설정 세션 무효화와 신청 API 하위호환 보완

### DIFF
--- a/src/main/java/org/forif_backend/application/product/ProductService.java
+++ b/src/main/java/org/forif_backend/application/product/ProductService.java
@@ -1,6 +1,7 @@
 package org.forif_backend.application.product;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.forif_backend.application.product.dto.CreateProductApplicationCommand;
 import org.forif_backend.application.file.port.out.FilePort;
 import org.forif_backend.application.product.dto.ProductInfo;
@@ -16,6 +17,8 @@ import org.forif_backend.domain.user.UserRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -23,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -85,7 +89,9 @@ public class ProductService {
 
         if (thumbnail != null && !thumbnail.isEmpty()) {
             validateImageFile(thumbnail);
-            product.updateThumbnail(filePort.uploadFile(thumbnail, THUMBNAIL_DIRECTORY));
+            String objectKey = filePort.uploadFile(thumbnail, THUMBNAIL_DIRECTORY);
+            product.updateThumbnail(objectKey);
+            deleteUploadOnRollback(objectKey);
         }
 
         try {
@@ -255,5 +261,24 @@ public class ProductService {
             throw new ForifException(ErrorCode.PRODUCT_URL_INVALID);
         }
         return trimmed;
+    }
+
+    /** 슬러그 경합 등으로 신청이 롤백되면 방금 올린 썸네일이 고아로 남지 않게 회수한다 */
+    private void deleteUploadOnRollback(String objectKey) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status != STATUS_COMMITTED) {
+                    try {
+                        filePort.deleteFile(objectKey);
+                    } catch (Exception e) {
+                        log.warn("롤백 후 썸네일 회수 실패: {}", objectKey, e);
+                    }
+                }
+            }
+        });
     }
 }

--- a/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
+++ b/src/main/java/org/forif_backend/application/staff/StaffAccountService.java
@@ -146,6 +146,11 @@ public class StaffAccountService {
         }
         String encodedPassword = password != null ? passwordEncoder.encode(password) : null;
         staffAccount.updateInfo(name, encodedPassword, affiliation);
+
+        if (password != null) {
+            // 운영진 재설정 경로도 유출 대응이므로 기존 MENTOR 세션을 끊는다 (updateAdmin과 동일 정책)
+            refreshTokenService.deleteRefreshToken(userId.toString(), StaffRole.MENTOR.getValue());
+        }
     }
 
     /**
@@ -387,6 +392,9 @@ public class StaffAccountService {
         if (password != null) {
             PasswordUtils.validate(password);
             staffAccount.updatePassword(passwordEncoder.encode(password));
+            // 비밀번호 재설정은 대개 유출 대응이다. 셀프 변경처럼 기존 세션을 끊지 않으면
+            // 탈취범의 refresh 토큰이 30일 동안 계속 로테이션되며 살아남는다.
+            refreshTokenService.deleteRefreshToken(targetUserId.toString(), StaffRole.ADMIN.getValue());
         }
         if (affiliation != null) {
             if ("회장".equals(affiliation) || "부회장".equals(affiliation)

--- a/src/main/java/org/forif_backend/web/product/ProductController.java
+++ b/src/main/java/org/forif_backend/web/product/ProductController.java
@@ -55,6 +55,17 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.from(info)));
     }
 
+    /** 썸네일 없이 JSON으로 보내던 기존 클라이언트가 415를 받지 않도록 병행 유지한다 */
+    @Operation(summary = "서비스 등록 신청 (JSON)", description = "썸네일 없이 JSON 본문만으로 서비스 등록을 신청합니다.")
+    @PostMapping(value = "/applications", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<ProductApplicationResponse>> applyProductJson(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody CreateProductApplicationRequest request
+    ) {
+        ProductInfo info = productService.applyProduct(userId, request.toCommand(), null);
+        return ResponseEntity.ok(ApiResponse.success(ProductApplicationResponse.from(info)));
+    }
+
     @Operation(summary = "서비스 상세 조회", description = "게시된 서비스의 상세 정보를 조회합니다. 인증 없이 접근 가능합니다.")
     @GetMapping("/{slug}")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(

--- a/src/test/java/org/forif_backend/application/staff/StaffAccountServicePasswordResetTest.java
+++ b/src/test/java/org/forif_backend/application/staff/StaffAccountServicePasswordResetTest.java
@@ -1,0 +1,106 @@
+package org.forif_backend.application.staff;
+
+import org.forif_backend.application.auth.RefreshTokenService;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.common.auth.JwtProvider;
+import org.forif_backend.domain.staff.StaffAccount;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.staff.StaffRole;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.team.ForifTeamRepository;
+import org.forif_backend.domain.user.User;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 회장단의 비밀번호 재설정도 기존 세션을 끊어야 한다.
+ * 재설정은 대개 유출 대응인데, refresh 토큰이 살아 있으면
+ * 탈취범이 30일 동안 로테이션으로 접근을 유지한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StaffAccountServicePasswordResetTest {
+
+    private static final Long PRESIDENT_ID = 20260001L;
+    private static final Long TARGET_ID = 20260002L;
+    private static final String NEW_PASSWORD = "ResetPass1!";
+
+    @Mock private SemesterService semesterService;
+    @Mock private StaffAccountRepository staffAccountRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private UserRepository userRepository;
+    @Mock private StudyRepository studyRepository;
+    @Mock private ForifTeamRepository forifTeamRepository;
+    @InjectMocks private StaffAccountService staffAccountService;
+
+    private StaffAccount president() {
+        StaffAccount account = mock(StaffAccount.class);
+        when(account.getUserId()).thenReturn(PRESIDENT_ID);
+        when(account.getAffiliation()).thenReturn("회장");
+        return account;
+    }
+
+    private StaffAccount targetAdmin() {
+        StaffAccount account = mock(StaffAccount.class);
+        when(account.getAffiliation()).thenReturn("운영진");
+        return account;
+    }
+
+    @Test
+    void 운영진_비밀번호_재설정은_대상자의_ADMIN_세션을_무효화한다() {
+        StaffAccount president = president();
+        StaffAccount target = targetAdmin();
+        when(staffAccountRepository.findByUserIdAndRole(PRESIDENT_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(president));
+        when(staffAccountRepository.findByUserIdAndRole(TARGET_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(target));
+        when(passwordEncoder.encode(NEW_PASSWORD)).thenReturn("encoded");
+
+        staffAccountService.updateAdmin(PRESIDENT_ID, TARGET_ID, null, NEW_PASSWORD, null);
+
+        verify(refreshTokenService).deleteRefreshToken(TARGET_ID.toString(), StaffRole.ADMIN.getValue());
+    }
+
+    @Test
+    void 비밀번호를_바꾸지_않는_수정은_세션을_건드리지_않는다() {
+        StaffAccount president = president();
+        StaffAccount target = targetAdmin();
+        when(staffAccountRepository.findByUserIdAndRole(PRESIDENT_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(president));
+        when(staffAccountRepository.findByUserIdAndRole(TARGET_ID, StaffRole.ADMIN))
+                .thenReturn(Optional.of(target));
+
+        staffAccountService.updateAdmin(PRESIDENT_ID, TARGET_ID, "새이름", null, null);
+
+        verify(refreshTokenService, never()).deleteRefreshToken(TARGET_ID.toString(), StaffRole.ADMIN.getValue());
+    }
+
+    @Test
+    void 멘토_비밀번호_재설정은_대상자의_MENTOR_세션을_무효화한다() {
+        StaffAccount mentor = mock(StaffAccount.class);
+        when(mentor.getUser()).thenReturn(mock(User.class));
+        when(staffAccountRepository.findByUserIdAndRole(TARGET_ID, StaffRole.MENTOR))
+                .thenReturn(Optional.of(mentor));
+        when(passwordEncoder.encode(NEW_PASSWORD)).thenReturn("encoded");
+
+        staffAccountService.updateMentorAccount(TARGET_ID, null, NEW_PASSWORD, null);
+
+        verify(refreshTokenService).deleteRefreshToken(TARGET_ID.toString(), StaffRole.MENTOR.getValue());
+    }
+}


### PR DESCRIPTION
#98·#99 머지 후 리뷰에서 확정된 결함의 후속 수정입니다.

## 비밀번호 재설정 세션 무효화 (#98 후속)

회장단이 운영진(`updateAdmin`)·멘토(`updateMentorAccount`) 비밀번호를 재설정할 때 대상자의 refresh 토큰을 함께 삭제합니다.

재설정은 대개 계정 유출 대응인데, 기존에는 셀프 변경 경로만 토큰을 지웠습니다. 탈취범이 refresh 토큰을 쥐고 있으면 비밀번호를 재설정해도 30일 동안 로테이션으로 접근을 유지할 수 있었습니다. 이제 재설정 즉시 세션이 끊깁니다.

비밀번호를 바꾸지 않는 정보 수정은 세션을 건드리지 않습니다.

## 서비스 등록 신청 하위호환 (#99 후속)

**JSON 매핑 병행 유지** — #99에서 `POST /api/v1/products/applications`가 multipart 전용이 되면서, 배포된 프론트의 JSON 신청이 415로 전면 실패하는 상태였습니다. 같은 경로에 `consumes = APPLICATION_JSON` 매핑을 추가해 썸네일 없는 기존 클라이언트는 그대로 동작합니다. 프론트가 multipart로 전환한 뒤 JSON 매핑 제거 여부는 그때 결정하면 됩니다.

**롤백 시 썸네일 회수** — 업로드가 `save`보다 먼저 실행되므로 슬러그 경합(`DataIntegrityViolation`) 등으로 롤백되면 업로드된 객체가 고아로 남았습니다. `afterCompletion`에서 롤백 시 회수합니다 (#96의 `deleteStoredFilesAfterCompletion` 선례와 같은 패턴).

## 반영 안 한 것

#98 리뷰의 "비밀번호 변경 후에도 발급된 access 토큰이 최대 1시간 유효" 건은 토큰 버전 클레임 같은 구조 변경이 필요해 이 PR에서 다루지 않습니다. access 수명이 1시간이라 노출 창이 제한적입니다.

## 검증

- `StaffAccountServicePasswordResetTest` 3케이스 신규 (ADMIN/MENTOR 재설정 시 무효화, 비변경 수정 시 미개입)
- 전체 테스트 통과, 스키마 변경 없음