### PR TITLE
Feature/for 135

### DIFF
--- a/docs/add-autonomous-study-flag.sql
+++ b/docs/add-autonomous-study-flag.sql
@@ -1,0 +1,33 @@
+-- 자율스터디 판정 및 학기당 1개 제약
+-- release 프로필은 ddl-auto: validate 이므로 애플리케이션 배포 전에 실행해야 합니다.
+-- MySQL DDL은 암묵적으로 커밋되므로, 아래 순서를 한 트랜잭션으로 감싸지 않습니다.
+
+ALTER TABLE tb_study
+    ADD COLUMN autonomous_flag TINYINT NULL DEFAULT NULL;
+
+-- [사전 확인]
+-- 기존에 '자율스터디'라는 이름의 데이터가 있으면 실제 자율스터디인지 먼저 확인합니다.
+-- 이름만으로 일반 스터디와 구분할 수 없으므로 자동 UPDATE를 실행하지 않습니다.
+SELECT study_id, act_year, act_semester, study_name, study_status
+FROM tb_study
+WHERE study_name = '자율스터디'
+ORDER BY act_year, act_semester, study_id;
+
+-- [기존 자율스터디 이관]
+-- 위 조회 결과에서 실제 자율스터디로 확인한 study_id만 명시해 실행합니다.
+-- 기존 데이터가 없다면 이 단계는 건너뜁니다.
+-- UPDATE tb_study
+-- SET autonomous_flag = 1
+-- WHERE study_id IN (<확인한_자율스터디_ID>);
+
+-- [유니크 제약 추가 전 확인]
+-- 결과가 있으면 동일 학기에 자율스터디가 둘 이상이므로 데이터를 정리한 뒤 다음 DDL을 실행합니다.
+SELECT act_year, act_semester, COUNT(*) AS autonomous_study_count
+FROM tb_study
+WHERE autonomous_flag = 1
+GROUP BY act_year, act_semester
+HAVING COUNT(*) > 1;
+
+ALTER TABLE tb_study
+    ADD CONSTRAINT uk_study_autonomous_semester
+        UNIQUE (act_year, act_semester, autonomous_flag);

--- a/src/main/java/org/forif_backend/application/semester/SemesterPhaseGuard.java
+++ b/src/main/java/org/forif_backend/application/semester/SemesterPhaseGuard.java
@@ -81,4 +81,17 @@ public class SemesterPhaseGuard {
                 .map(schedule -> schedule.contains(LocalDateTime.now()))
                 .orElse(true);
     }
+
+    /**
+     * 모집 시작 전에는 허용하되, 해당 모집 단계가 끝난 뒤에는 새 대상을 만들지 못하게 한다.
+     * 일정이 없는 학기는 기존 fail-open 정책을 따른다.
+     */
+    @Transactional(readOnly = true)
+    public void requireNotEnded(SemesterPhase phase, int actYear, int actSemester) {
+        Optional<SemesterSchedule> schedule =
+                semesterScheduleRepository.findByYearAndSemesterAndPhase(actYear, actSemester, phase);
+        if (schedule.isPresent() && !LocalDateTime.now().isBefore(schedule.get().getEndsAt())) {
+            throw new ForifException(ErrorCode.SEMESTER_PHASE_CLOSED);
+        }
+    }
 }

--- a/src/main/java/org/forif_backend/application/semester/SemesterService.java
+++ b/src/main/java/org/forif_backend/application/semester/SemesterService.java
@@ -52,6 +52,16 @@ public class SemesterService {
                 });
     }
 
+    /**
+     * 현재 활동 학기를 잠근 채 조회한다. 학기별 단일 리소스 생성 시 중복 생성을 막는 데 사용한다.
+     */
+    @Transactional
+    public SemesterInfo getActiveForUpdate() {
+        return semesterRepository.findActiveForUpdate()
+                .map(SemesterInfo::from)
+                .orElseThrow(() -> new ForifException(ErrorCode.SEMESTER_INVALID));
+    }
+
     public int getActiveYear() {
         return getActive().actYear();
     }

--- a/src/main/java/org/forif_backend/application/study/CertificateService.java
+++ b/src/main/java/org/forif_backend/application/study/CertificateService.java
@@ -151,6 +151,10 @@ public class CertificateService {
     public String issueManualCertificate(String userName, String studentNumber, String department,
                                          String studyName, String activityPeriod, String issueDate,
                                          String presidentName) {
+        if (Study.AUTONOMOUS_STUDY_NAME.equals(studyName == null ? null : studyName.trim())) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED);
+        }
+
         String resolvedIssueDate = issueDate == null || issueDate.isBlank()
                 ? LocalDate.now().format(ISSUE_DATE_FORMAT)
                 : issueDate;
@@ -268,7 +272,11 @@ public class CertificateService {
     }
 
     private Study getStudy(Integer studyId) {
-        return studyRepository.findStudyById(studyId)
+        Study study = studyRepository.findStudyById(studyId)
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
+        if (study.isAutonomousStudy()) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED);
+        }
+        return study;
     }
 }

--- a/src/main/java/org/forif_backend/application/study/StudyAttendanceService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyAttendanceService.java
@@ -120,6 +120,7 @@ public class StudyAttendanceService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         studyMentorAccess.requireMentor(study, userId);
+        requireAttendanceTarget(study);
         return study;
     }
 
@@ -129,6 +130,13 @@ public class StudyAttendanceService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         studyMentorAccess.requireMentorOfActiveSemester(study, userId);
+        requireAttendanceTarget(study);
         return study;
+    }
+
+    private void requireAttendanceTarget(Study study) {
+        if (study.isAutonomousStudy()) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED);
+        }
     }
 }

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -247,6 +247,10 @@ public class StudyService {
 
     private void applyStudyUpdate(Integer studyId, Study study, UpdateStudyRequest request) {
         // null이 아닌 기본 필드만 반영
+        if (!study.isAutonomousStudy()
+                && Study.isAutonomousStudyName(request.getStudyName())) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_NAME_RESERVED);
+        }
         if (study.isAutonomousStudy()
                 && request.getStudyName() != null
                 && !Study.AUTONOMOUS_STUDY_NAME.equals(request.getStudyName())) {
@@ -378,6 +382,7 @@ public class StudyService {
     public CreateStudyApplyInfo createStudyApply(Long mentorId, CreateStudyApplyRequest request,
                                                  MultipartFile thumbnail, List<MultipartFile> referenceFiles) {
         semesterPhaseGuard.requireOpen(SemesterPhase.MENTOR_RECRUIT);
+        requireRegularStudyName(request.getTitle());
 
         User mentor = userRepository.findUserById(mentorId)
                 .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
@@ -636,6 +641,7 @@ public class StudyService {
     private CreateStudyApplyInfo updateStudyApplication(Integer studyId, Long userId, CreateStudyApplyRequest request,
                                                          MultipartFile thumbnail, List<MultipartFile> referenceFiles,
                                                          boolean rejectedOnly) {
+        requireRegularStudyName(request.getTitle());
         Study study = findModifiableStudyApplication(studyId, userId, rejectedOnly);
 
         List<StudyTag> tags = resolveStudyTags(request);
@@ -816,12 +822,13 @@ public class StudyService {
     public void createAutonomousStudy(Long adminUserId) {
         // 활성 학기 행을 잠가 여러 운영진이 동시에 요청해도 존재 확인과 저장이 직렬화된다.
         SemesterInfo semester = semesterService.getActiveForUpdate();
+        // 정규 스터디와 같은 멘티 모집 흐름을 쓰므로, 모집이 끝난 뒤에는 빈 스터디 생성을 막는다.
+        // 모집 시작 전 개설은 허용해 일정이 열리는 즉시 신청을 받을 수 있다.
+        semesterPhaseGuard.requireNotEnded(
+                SemesterPhase.MENTEE_RECRUIT, semester.actYear(), semester.actSemester());
 
-        if (studyRepository.existsByActYearAndActSemesterAndStudyName(
-                semester.actYear(),
-                semester.actSemester(),
-                Study.AUTONOMOUS_STUDY_NAME
-        )) {
+        if (studyRepository.existsByActYearAndActSemesterAndAutonomousFlagTrue(
+                semester.actYear(), semester.actSemester())) {
             throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_ALREADY_EXISTS);
         }
 
@@ -838,6 +845,12 @@ public class StudyService {
                 LocalDateTime.now()
         ));
         studyRepository.saveStudy(study);
+    }
+
+    private void requireRegularStudyName(String studyName) {
+        if (Study.isAutonomousStudyName(studyName)) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_NAME_RESERVED);
+        }
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -803,6 +803,39 @@ public class StudyService {
     }
 
     /**
+     * [어드민 전용] 현재 활동 학기의 자율스터디를 즉시 개설한다.
+     * 자율스터디도 일반 스터디와 같은 엔티티와 수강 신청 흐름을 사용하지만,
+     * 멘토 개설 신청 및 심사 과정은 거치지 않으며, 개설한 운영진이 대표 멘토가 된다.
+     */
+    @Transactional
+    public void createAutonomousStudy(Long adminUserId) {
+        // 활성 학기 행을 잠가 여러 운영진이 동시에 요청해도 존재 확인과 저장이 직렬화된다.
+        SemesterInfo semester = semesterService.getActiveForUpdate();
+
+        if (studyRepository.existsByActYearAndActSemesterAndStudyName(
+                semester.actYear(),
+                semester.actSemester(),
+                Study.AUTONOMOUS_STUDY_NAME
+        )) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_ALREADY_EXISTS);
+        }
+
+        User admin = userRepository.findUserById(adminUserId)
+                .orElseThrow(() -> new ForifException(ErrorCode.USER_NOT_FOUND));
+        Study study = Study.createAutonomousStudy(
+                admin,
+                semester.actYear(),
+                semester.actSemester()
+        );
+        study.setRecruitStatus(recruitStatusPolicy.resolve(
+                semester.actYear(),
+                semester.actSemester(),
+                LocalDateTime.now()
+        ));
+        studyRepository.saveStudy(study);
+    }
+
+    /**
      * [어드민 전용] 스터디 개설 거절
      */
     @Transactional

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -247,6 +247,11 @@ public class StudyService {
 
     private void applyStudyUpdate(Integer studyId, Study study, UpdateStudyRequest request) {
         // null이 아닌 기본 필드만 반영
+        if (study.isAutonomousStudy()
+                && request.getStudyName() != null
+                && !Study.AUTONOMOUS_STUDY_NAME.equals(request.getStudyName())) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_NAME_NOT_CHANGEABLE);
+        }
         if (request.getStudyName() != null) study.setStudyName(request.getStudyName());
         if (request.getOneLiner() != null) study.setOneLiner(request.getOneLiner());
         if (request.getExplanation() != null) study.setExplanation(request.getExplanation());

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -89,6 +89,8 @@ public enum ErrorCode {
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR077-404", "파일을 찾을 수 없습니다."),
     CURRENT_SEMESTER_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR128-404", "현재 활동 학기에 등록된 부원이 아닙니다."),
     STUDY_CANCEL_HAS_DEPENDENTS(HttpStatus.BAD_REQUEST, "FOR130-400", "지원서나 수강 기록이 있는 스터디는 취소할 수 없습니다. 운영진에게 문의해주세요."),
+    AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOR132-400", "자율스터디는 출석 체크 및 수료증 발급 대상이 아닙니다."),
+    AUTONOMOUS_STUDY_NAME_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR133-400", "자율스터디의 이름은 변경할 수 없습니다."),
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR044-409", "이미 가입된 사용자입니다."),

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -91,6 +91,7 @@ public enum ErrorCode {
     STUDY_CANCEL_HAS_DEPENDENTS(HttpStatus.BAD_REQUEST, "FOR130-400", "지원서나 수강 기록이 있는 스터디는 취소할 수 없습니다. 운영진에게 문의해주세요."),
     AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOR132-400", "자율스터디는 출석 체크 및 수료증 발급 대상이 아닙니다."),
     AUTONOMOUS_STUDY_NAME_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR133-400", "자율스터디의 이름은 변경할 수 없습니다."),
+    AUTONOMOUS_STUDY_NAME_RESERVED(HttpStatus.BAD_REQUEST, "FOR134-400", "자율스터디 명칭은 일반 스터디에 사용할 수 없습니다."),
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR044-409", "이미 가입된 사용자입니다."),

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -98,6 +98,7 @@ public enum ErrorCode {
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR048-409", "이미 가입된 이메일입니다."),
     HACKATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR074-409", "이미 등록된 해커톤입니다."),
     HACKATHON_ACTIVE_EVENT_EXISTS(HttpStatus.CONFLICT, "FOR076-409", "진행 중인 해커톤이 있어 새 해커톤을 생성할 수 없습니다."),
+    AUTONOMOUS_STUDY_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR131-409", "현재 학기에 자율스터디가 이미 개설되어 있습니다."),
 
     // Product (서비스 쇼케이스)
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR110-404", "해당 서비스를 찾을 수 없습니다."),

--- a/src/main/java/org/forif_backend/domain/semester/SemesterRepository.java
+++ b/src/main/java/org/forif_backend/domain/semester/SemesterRepository.java
@@ -6,6 +6,9 @@ public interface SemesterRepository {
 
     Optional<ActiveSemester> findActive();
 
+    /** 자율스터디처럼 학기 단위의 단일 자원을 생성할 때 동시 요청을 직렬화한다. */
+    Optional<ActiveSemester> findActiveForUpdate();
+
     ActiveSemester save(ActiveSemester activeSemester);
 
     void saveChangeLog(SemesterChangeLog log);

--- a/src/main/java/org/forif_backend/domain/study/Study.java
+++ b/src/main/java/org/forif_backend/domain/study/Study.java
@@ -23,6 +23,14 @@ import org.forif_backend.web.study.dto.CreateStudyApplyRequest;
 @Table(name = "tb_study")
 public class Study extends BaseTimeEntity {
 
+    public static final String AUTONOMOUS_STUDY_NAME = "자율스터디";
+    private static final String AUTONOMOUS_STUDY_ONE_LINER =
+            "공통의 관심사로 원하는 분야를 자유롭게 공부하는 스터디";
+    private static final String AUTONOMOUS_STUDY_EXPLANATION =
+            "자율스터디는 공통의 관심사를 가진 부원들이 모여 자유롭게 원하는 분야를 공부하는 스터디입니다. "
+                    + "자율스터디는 FORIF 인증서가 발급되지 않으며, 출석 체크 대상에도 포함되지 않고 정해진 수업 회차나 일정이 없습니다. "
+                    + "자율부원은 정규 스터디를 수강하지 않고 FORIF에 등록한 부원으로, 정규스터디 영역 외에는 FORIF 부원으로서 다양한 혜택을 누릴 수 있습니다.";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "study_id")
@@ -139,6 +147,23 @@ public class Study extends BaseTimeEntity {
         study.actYear = actYear;
         study.actSemester = actSemester;
 
+        return study;
+    }
+
+    /**
+     * 운영진이 학기별로 개설하는 자율스터디를 생성한다.
+     * 자율스터디는 멘토 개설 신청을 거치지 않지만, 신청자를 관리할 운영진을 대표 멘토로 둔다.
+     */
+    public static Study createAutonomousStudy(User mentor, int actYear, int actSemester) {
+        Study study = new Study();
+        study.actYear = actYear;
+        study.actSemester = actSemester;
+        study.studyName = AUTONOMOUS_STUDY_NAME;
+        study.primaryMentor = mentor;
+        study.primaryMentorName = mentor.getUserName();
+        study.oneLiner = AUTONOMOUS_STUDY_ONE_LINER;
+        study.explanation = AUTONOMOUS_STUDY_EXPLANATION;
+        study.studyStatus = StudyStatus.APPROVED;
         return study;
     }
 

--- a/src/main/java/org/forif_backend/domain/study/Study.java
+++ b/src/main/java/org/forif_backend/domain/study/Study.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Setter;
 
 import org.forif_backend.common.BaseTimeEntity;
@@ -20,7 +21,13 @@ import org.forif_backend.web.study.dto.CreateStudyApplyRequest;
 @Getter
 @Setter
 @NoArgsConstructor
-@Table(name = "tb_study")
+@Table(
+        name = "tb_study",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_study_autonomous_semester",
+                columnNames = {"act_year", "act_semester", "autonomous_flag"}
+        )
+)
 public class Study extends BaseTimeEntity {
 
     public static final String AUTONOMOUS_STUDY_NAME = "자율스터디";
@@ -44,6 +51,11 @@ public class Study extends BaseTimeEntity {
 
     @Column(length = 50)
     private String studyName;
+
+    /** 자율스터디만 true이며, 일반 스터디는 NULL로 보관한다. */
+    @Setter(AccessLevel.NONE)
+    @Column(name = "autonomous_flag")
+    private Boolean autonomousFlag;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "primary_mentor_id")
@@ -137,7 +149,11 @@ public class Study extends BaseTimeEntity {
 
     /** 자율스터디는 출석 및 수료증 발급 대상이 아니다. */
     public boolean isAutonomousStudy() {
-        return AUTONOMOUS_STUDY_NAME.equals(this.studyName);
+        return Boolean.TRUE.equals(this.autonomousFlag);
+    }
+
+    public static boolean isAutonomousStudyName(String studyName) {
+        return AUTONOMOUS_STUDY_NAME.equals(studyName);
     }
 
     /**
@@ -164,6 +180,7 @@ public class Study extends BaseTimeEntity {
         study.actYear = actYear;
         study.actSemester = actSemester;
         study.studyName = AUTONOMOUS_STUDY_NAME;
+        study.autonomousFlag = true;
         study.primaryMentor = mentor;
         study.primaryMentorName = mentor.getUserName();
         study.oneLiner = AUTONOMOUS_STUDY_ONE_LINER;

--- a/src/main/java/org/forif_backend/domain/study/Study.java
+++ b/src/main/java/org/forif_backend/domain/study/Study.java
@@ -135,6 +135,11 @@ public class Study extends BaseTimeEntity {
         return isPrimary || isSecondary;
     }
 
+    /** 자율스터디는 출석 및 수료증 발급 대상이 아니다. */
+    public boolean isAutonomousStudy() {
+        return AUTONOMOUS_STUDY_NAME.equals(this.studyName);
+    }
+
     /**
      * 초기 스터디 생성 메서드
      * @param mentor 멘토 유저

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -8,6 +8,7 @@ import org.forif_backend.domain.user.User;
 
 public interface StudyRepository {
     Optional<Study> findStudyById(Integer studyId);
+    boolean existsByActYearAndActSemesterAndStudyName(int actYear, int actSemester, String studyName);
     List<StudyTag> findAllStudyTagById(List<Long> tagIds);
     List<StudyTag> findAllStudyTagByName(List<String> tagNames);
     List<Study> getStudies(StudySearchCond cond, Integer cursor, int size);

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -8,7 +8,7 @@ import org.forif_backend.domain.user.User;
 
 public interface StudyRepository {
     Optional<Study> findStudyById(Integer studyId);
-    boolean existsByActYearAndActSemesterAndStudyName(int actYear, int actSemester, String studyName);
+    boolean existsByActYearAndActSemesterAndAutonomousFlagTrue(int actYear, int actSemester);
     List<StudyTag> findAllStudyTagById(List<Long> tagIds);
     List<StudyTag> findAllStudyTagByName(List<String> tagNames);
     List<Study> getStudies(StudySearchCond cond, Integer cursor, int size);

--- a/src/main/java/org/forif_backend/infrastructure/persistence/semester/ActiveSemesterJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/semester/ActiveSemesterJpaRepository.java
@@ -1,7 +1,17 @@
 package org.forif_backend.infrastructure.persistence.semester;
 
 import org.forif_backend.domain.semester.ActiveSemester;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ActiveSemesterJpaRepository extends JpaRepository<ActiveSemester, Integer> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT semester FROM ActiveSemester semester WHERE semester.id = :id")
+    Optional<ActiveSemester> findByIdForUpdate(@Param("id") Integer id);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/semester/SemesterRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/semester/SemesterRepositoryImpl.java
@@ -21,6 +21,11 @@ public class SemesterRepositoryImpl implements SemesterRepository {
     }
 
     @Override
+    public Optional<ActiveSemester> findActiveForUpdate() {
+        return activeSemesterJpaRepository.findByIdForUpdate(ActiveSemester.SINGLETON_ID);
+    }
+
+    @Override
     public ActiveSemester save(ActiveSemester activeSemester) {
         return activeSemesterJpaRepository.save(activeSemester);
     }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyJpaRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public interface StudyJpaRepository extends JpaRepository<Study, Integer> {
 
-    boolean existsByActYearAndActSemesterAndStudyName(int actYear, int actSemester, String studyName);
+    boolean existsByActYearAndActSemesterAndAutonomousFlagTrue(int actYear, int actSemester);
 
     @Query("SELECT DISTINCT s FROM Study s LEFT JOIN FETCH s.tags WHERE s.id = :studyId")
     Optional<Study> findByIdWithTags(@Param("studyId") Integer studyId);

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyJpaRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyJpaRepository.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 
 public interface StudyJpaRepository extends JpaRepository<Study, Integer> {
 
+    boolean existsByActYearAndActSemesterAndStudyName(int actYear, int actSemester, String studyName);
+
     @Query("SELECT DISTINCT s FROM Study s LEFT JOIN FETCH s.tags WHERE s.id = :studyId")
     Optional<Study> findByIdWithTags(@Param("studyId") Integer studyId);
 

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -30,8 +30,8 @@ public class StudyRepositoryImpl implements StudyRepository {
     }
 
     @Override
-    public boolean existsByActYearAndActSemesterAndStudyName(int actYear, int actSemester,String studyName) {
-        return studyJpaRepository.existsByActYearAndActSemesterAndStudyName(actYear, actSemester, studyName);
+    public boolean existsByActYearAndActSemesterAndAutonomousFlagTrue(int actYear, int actSemester) {
+        return studyJpaRepository.existsByActYearAndActSemesterAndAutonomousFlagTrue(actYear, actSemester);
     }
 
     @Override

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -30,6 +30,11 @@ public class StudyRepositoryImpl implements StudyRepository {
     }
 
     @Override
+    public boolean existsByActYearAndActSemesterAndStudyName(int actYear, int actSemester,String studyName) {
+        return studyJpaRepository.existsByActYearAndActSemesterAndStudyName(actYear, actSemester, studyName);
+    }
+
+    @Override
     public List<Study> getStudies(StudySearchCond cond, Integer cursor, int size) {
         return studyQueryRepository.searchStudies(cond, cursor, size);
     }

--- a/src/main/java/org/forif_backend/web/study/StudyController.java
+++ b/src/main/java/org/forif_backend/web/study/StudyController.java
@@ -119,6 +119,19 @@ public class StudyController {
     }
 
     /**
+     * [어드민 전용] 자율스터디 개설
+     */
+    @Operation(summary = "자율스터디 개설 (어드민 전용)", description = "현재 활동 학기에 자율스터디를 즉시 개설하고, 개설한 운영진을 대표 멘토로 지정합니다. 같은 학기에는 한 번만 개설할 수 있습니다.")
+    @PostMapping("/api/v1/admin/studies/autonomous")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> createAutonomousStudy(
+            @AuthenticationPrincipal Long userId
+    ) {
+        studyService.createAutonomousStudy(userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    /**
      * [어드민용] 스터디 삭제
      */
     @Operation(summary = "스터디 삭제 (어드민 전용)", description = "스터디와 관련된 플랜, 참고자료, 수강자 정보를 모두 삭제합니다.")

--- a/src/test/java/org/forif_backend/application/semester/SemesterPhaseGuardTest.java
+++ b/src/test/java/org/forif_backend/application/semester/SemesterPhaseGuardTest.java
@@ -1,0 +1,57 @@
+package org.forif_backend.application.semester;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.semester.SemesterPhase;
+import org.forif_backend.domain.semester.SemesterSchedule;
+import org.forif_backend.domain.semester.SemesterScheduleRepository;
+import org.junit.jupiter.api.Test;
+
+class SemesterPhaseGuardTest {
+
+    private final SemesterScheduleRepository scheduleRepository = mock(SemesterScheduleRepository.class);
+    private final SemesterPhaseGuard guard = new SemesterPhaseGuard(
+            scheduleRepository, mock(SemesterService.class));
+
+    @Test
+    void allowsCreatingAStudyBeforeMenteeRecruitmentStarts() {
+        when(scheduleRepository.findByYearAndSemesterAndPhase(2026, 2, SemesterPhase.MENTEE_RECRUIT))
+                .thenReturn(Optional.of(SemesterSchedule.create(
+                        2026,
+                        2,
+                        SemesterPhase.MENTEE_RECRUIT,
+                        LocalDateTime.now().plusDays(1),
+                        LocalDateTime.now().plusDays(7),
+                        1L
+                )));
+
+        assertThatCode(() -> guard.requireNotEnded(SemesterPhase.MENTEE_RECRUIT, 2026, 2))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void blocksCreatingAStudyAfterMenteeRecruitmentEnds() {
+        when(scheduleRepository.findByYearAndSemesterAndPhase(2026, 2, SemesterPhase.MENTEE_RECRUIT))
+                .thenReturn(Optional.of(SemesterSchedule.create(
+                        2026,
+                        2,
+                        SemesterPhase.MENTEE_RECRUIT,
+                        LocalDateTime.now().minusDays(7),
+                        LocalDateTime.now().minusDays(1),
+                        1L
+                )));
+
+        assertThatThrownBy(() -> guard.requireNotEnded(SemesterPhase.MENTEE_RECRUIT, 2026, 2))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> org.assertj.core.api.Assertions.assertThat(
+                        ((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.SEMESTER_PHASE_CLOSED));
+    }
+}

--- a/src/test/java/org/forif_backend/application/study/AutonomousStudyOperationTest.java
+++ b/src/test/java/org/forif_backend/application/study/AutonomousStudyOperationTest.java
@@ -1,0 +1,73 @@
+package org.forif_backend.application.study;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.forif_backend.application.file.port.out.FilePort;
+import org.forif_backend.common.exception.ErrorCode;
+import org.forif_backend.common.exception.ForifException;
+import org.forif_backend.domain.hackathon.HackathonRepository;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.study.StudyAttendanceRepository;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.StudyUserRepository;
+import org.junit.jupiter.api.Test;
+
+class AutonomousStudyOperationTest {
+
+    @Test
+    void blocksAttendanceForAnAutonomousStudy() {
+        StudyRepository studyRepository = mock(StudyRepository.class);
+        Study study = mock(Study.class);
+        StudyUserRepository studyUserRepository = mock(StudyUserRepository.class);
+        StudyAttendanceRepository attendanceRepository = mock(StudyAttendanceRepository.class);
+        StudyAttendanceService service = new StudyAttendanceService(
+                studyRepository,
+                mock(StudyMentorAccess.class),
+                studyUserRepository,
+                attendanceRepository
+        );
+        when(studyRepository.findStudyById(1)).thenReturn(Optional.of(study));
+        when(study.isAutonomousStudy()).thenReturn(true);
+
+        assertThatThrownBy(() -> service.getAttendance(10L, 1))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> org.assertj.core.api.Assertions.assertThat(
+                        ((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED));
+
+        verify(studyUserRepository, never()).findAllByStudyId(1);
+        verify(attendanceRepository, never()).findAllByStudyId(1);
+    }
+
+    @Test
+    void blocksCertificatesForAnAutonomousStudy() {
+        StudyRepository studyRepository = mock(StudyRepository.class);
+        Study study = mock(Study.class);
+        StudyUserRepository studyUserRepository = mock(StudyUserRepository.class);
+        CertificateService service = new CertificateService(
+                studyRepository,
+                studyUserRepository,
+                mock(StudyAttendanceRepository.class),
+                mock(HackathonRepository.class),
+                mock(StaffAccountRepository.class),
+                mock(CertificateImageGenerator.class),
+                mock(FilePort.class)
+        );
+        when(studyRepository.findStudyById(1)).thenReturn(Optional.of(study));
+        when(study.isAutonomousStudy()).thenReturn(true);
+
+        assertThatThrownBy(() -> service.getCertificateTargets(1))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> org.assertj.core.api.Assertions.assertThat(
+                        ((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED));
+
+        verify(studyUserRepository, never()).findAllByStudyId(1);
+    }
+}

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -191,6 +191,23 @@ class StudyServiceApplicationUpdateTest {
     }
 
     @Test
+    void preventsRenamingAnAutonomousStudy() {
+        Study study = mock(Study.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setStudyName("변경된 스터디 이름");
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.isAutonomousStudy()).thenReturn(true);
+
+        assertThatThrownBy(() -> studyService.updateStudy(1, request))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_NAME_NOT_CHANGEABLE));
+
+        verify(study, never()).setStudyName("변경된 스터디 이름");
+    }
+
+    @Test
     void replacesExistingFileReferencesWhenMentorMultipartRequestOmitsRetainedReferenceIds() {
         Study study = mock(Study.class);
         StudyReference existingFileReference = mock(StudyReference.class);

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -208,6 +208,77 @@ class StudyServiceApplicationUpdateTest {
     }
 
     @Test
+    void preventsRenamingARegularStudyToTheReservedAutonomousStudyName() {
+        Study study = mock(Study.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setStudyName(Study.AUTONOMOUS_STUDY_NAME);
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.isAutonomousStudy()).thenReturn(false);
+
+        assertThatThrownBy(() -> studyService.updateStudy(1, request))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_NAME_RESERVED));
+
+        verify(study, never()).setStudyName(Study.AUTONOMOUS_STUDY_NAME);
+    }
+
+    @Test
+    void preventsUsingTheReservedNameWhenCreatingAStudyApplication() {
+        CreateStudyApplyRequest request = new CreateStudyApplyRequest();
+        request.setTitle(Study.AUTONOMOUS_STUDY_NAME);
+
+        assertThatThrownBy(() -> studyService.createStudyApply(10L, request, null, null))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_NAME_RESERVED));
+
+        verify(userRepository, never()).findUserById(10L);
+    }
+
+    @Test
+    void preventsUsingTheReservedNameWhenReapplyingForAStudy() {
+        CreateStudyApplyRequest request = new CreateStudyApplyRequest();
+        request.setTitle(Study.AUTONOMOUS_STUDY_NAME);
+
+        assertThatThrownBy(() -> studyService.reApplyStudy(1, 10L, request, null, null))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_NAME_RESERVED));
+
+        verify(studyRepository, never()).findStudyByIdWithTags(1);
+    }
+
+    @Test
+    void rejectsCreatingAnotherAutonomousStudyForTheActiveSemester() {
+        when(semesterService.getActiveForUpdate()).thenReturn(SemesterInfo.of(2026, 2));
+        when(studyRepository.existsByActYearAndActSemesterAndAutonomousFlagTrue(2026, 2)).thenReturn(true);
+
+        assertThatThrownBy(() -> studyService.createAutonomousStudy(10L))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_ALREADY_EXISTS));
+
+        verify(studyRepository, never()).saveStudy(org.mockito.ArgumentMatchers.any(Study.class));
+    }
+
+    @Test
+    void preventsCreatingAnAutonomousStudyAfterMenteeRecruitmentEnds() {
+        when(semesterService.getActiveForUpdate()).thenReturn(SemesterInfo.of(2026, 2));
+        doThrow(new ForifException(ErrorCode.SEMESTER_PHASE_CLOSED))
+                .when(semesterPhaseGuard)
+                .requireNotEnded(org.forif_backend.domain.semester.SemesterPhase.MENTEE_RECRUIT, 2026, 2);
+
+        assertThatThrownBy(() -> studyService.createAutonomousStudy(10L))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.SEMESTER_PHASE_CLOSED));
+
+        verify(studyRepository, never()).existsByActYearAndActSemesterAndAutonomousFlagTrue(2026, 2);
+    }
+
+    @Test
     void replacesExistingFileReferencesWhenMentorMultipartRequestOmitsRetainedReferenceIds() {
         Study study = mock(Study.class);
         StudyReference existingFileReference = mock(StudyReference.class);

--- a/src/test/java/org/forif_backend/domain/study/StudyTest.java
+++ b/src/test/java/org/forif_backend/domain/study/StudyTest.java
@@ -26,4 +26,14 @@ class StudyTest {
         assertThat(study.getExplanation()).isNotBlank();
         assertThat(study.isAutonomousStudy()).isTrue();
     }
+
+    @Test
+    void identifiesAnAutonomousStudyByTheDedicatedFlagInsteadOfItsName() {
+        User mentor = Mockito.mock(User.class);
+        given(mentor.getUserName()).willReturn("멘토");
+
+        Study regularStudy = Study.createPendingStudy(mentor, 2026, 2);
+
+        assertThat(regularStudy.isAutonomousStudy()).isFalse();
+    }
 }

--- a/src/test/java/org/forif_backend/domain/study/StudyTest.java
+++ b/src/test/java/org/forif_backend/domain/study/StudyTest.java
@@ -1,0 +1,28 @@
+package org.forif_backend.domain.study;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.forif_backend.domain.user.User;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class StudyTest {
+
+    @Test
+    void createsAutonomousStudyAsApprovedWithTheCreatingAdminAsPrimaryMentor() {
+        User admin = Mockito.mock(User.class);
+        given(admin.getUserName()).willReturn("운영진");
+
+        Study study = Study.createAutonomousStudy(admin, 2026, 2);
+
+        assertThat(study.getActYear()).isEqualTo(2026);
+        assertThat(study.getActSemester()).isEqualTo(2);
+        assertThat(study.getStudyName()).isEqualTo(Study.AUTONOMOUS_STUDY_NAME);
+        assertThat(study.getStudyStatus()).isEqualTo(StudyStatus.APPROVED);
+        assertThat(study.getPrimaryMentor()).isSameAs(admin);
+        assertThat(study.getPrimaryMentorName()).isEqualTo("운영진");
+        assertThat(study.getOneLiner()).isNotBlank();
+        assertThat(study.getExplanation()).isNotBlank();
+    }
+}

--- a/src/test/java/org/forif_backend/domain/study/StudyTest.java
+++ b/src/test/java/org/forif_backend/domain/study/StudyTest.java
@@ -24,5 +24,6 @@ class StudyTest {
         assertThat(study.getPrimaryMentorName()).isEqualTo("운영진");
         assertThat(study.getOneLiner()).isNotBlank();
         assertThat(study.getExplanation()).isNotBlank();
+        assertThat(study.isAutonomousStudy()).isTrue();
     }
 }


### PR DESCRIPTION
## 자율스터디 개설 및 운영 정책 적용

### 변경 사항

- 어드민에서 현재 활동 학기의 `자율스터디`를 개설할 수 있는 API를 추가했습니다.
- 개설을 실행한 운영진을 자율스터디의 대표 멘토로 자동 지정합니다.
- 자율스터디는 즉시 승인 상태로 생성되어 기존 스터디 목록 및 신청 흐름에 포함됩니다.
- 동일 학기에 자율스터디가 중복 개설되지 않도록 검증했습니다.
- 자율스터디의 한줄 소개와 소개 문구를 기본값으로 설정했습니다.
- 자율스터디는 출석 조회·기록 및 인증서 발급 대상에서 제외했습니다.
- 수기 인증서 발급과 자율스터디 이름 변경도 차단해 예외 정책이 유지되도록 했습니다.

### 검증

- `StudyTest` 통과
- `StudyServiceApplicationUpdateTest` 통과