### PR TITLE
fix(certificate): 수료증 다운로드 URL 저장 구조 변경

### DIFF
--- a/src/main/java/org/forif_backend/application/study/CertificateService.java
+++ b/src/main/java/org/forif_backend/application/study/CertificateService.java
@@ -128,7 +128,7 @@ public class CertificateService {
                             .eligible(attendanceCount >= REQUIRED_ATTENDANCE && hackathonParticipated)
                             .certificateStatus(mentee.getCertificateStatus() != null
                                     ? mentee.getCertificateStatus() : 0)
-                            .certificateUrl(mentee.getCertificateUrl())
+                            .certificateUrl(resolveCertificateViewUrl(mentee.getCertificateObjectKey()))
                             .build();
                 })
                 .toList();
@@ -242,7 +242,7 @@ public class CertificateService {
             String objectKey = filePort.uploadBytes(image, userId + ".png", directory, "image/png");
             String certificateUrl = filePort.generatePresignedViewUrl(objectKey).presignedUrl();
 
-            mentee.issueCertificate(certificateUrl);
+            mentee.issueCertificate(objectKey);
             studyUserRepository.save(mentee);
 
             results.add(itemResult(userId, userName, true, "발급 완료", certificateUrl));
@@ -265,6 +265,16 @@ public class CertificateService {
                 .message(message)
                 .certificateUrl(certificateUrl)
                 .build();
+    }
+
+    private String resolveCertificateViewUrl(String certificateObjectKey) {
+        if (certificateObjectKey == null || certificateObjectKey.isBlank()) {
+            return null;
+        }
+        if (certificateObjectKey.startsWith("http://") || certificateObjectKey.startsWith("https://")) {
+            return certificateObjectKey;
+        }
+        return filePort.generatePresignedViewUrl(certificateObjectKey).presignedUrl();
     }
 
     private Study getStudy(Integer studyId) {

--- a/src/main/java/org/forif_backend/application/user/UserService.java
+++ b/src/main/java/org/forif_backend/application/user/UserService.java
@@ -306,12 +306,20 @@ public class UserService {
             throw new ForifException(ErrorCode.CERTIFICATE_NOT_ISSUED);
         }
 
-        // 3. certificateUrl 확인
-        if (studyUser.getCertificateUrl() == null || studyUser.getCertificateUrl().isEmpty()) {
+        // 3. 수료증 파일 object key 확인
+        String certificateObjectKey = studyUser.getCertificateObjectKey();
+        if (certificateObjectKey == null || certificateObjectKey.isBlank()) {
             throw new ForifException(ErrorCode.CERTIFICATE_NOT_ISSUED);
         }
 
-        return new GetCertificateResult(studyUser.getCertificateUrl());
+        // 과거 발급분은 Presigned URL 자체가 저장되어 있을 수 있어 그대로 반환한다.
+        if (certificateObjectKey.startsWith("http://") || certificateObjectKey.startsWith("https://")) {
+            return new GetCertificateResult(certificateObjectKey);
+        }
+
+        return new GetCertificateResult(
+                filePort.generatePresignedViewUrl(certificateObjectKey).presignedUrl()
+        );
     }
 
     /**

--- a/src/main/java/org/forif_backend/domain/study/StudyUser.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyUser.java
@@ -25,8 +25,11 @@ public class StudyUser {
 
     private Integer certificateStatus;
 
-    @Column(length = 300)
-    private String certificateUrl;
+    /**
+     * 수료증 파일의 S3 object key. 기존에 저장된 Presigned URL도 하위 호환을 위해 읽을 수 있다.
+     */
+    @Column(name = "certificate_url", length = 300)
+    private String certificateObjectKey;
 
     public static StudyUser create(Study study, User user) {
         StudyUser studyUser = new StudyUser();
@@ -38,8 +41,8 @@ public class StudyUser {
     /**
      * 수료증 발급 처리 (0: 미발급, 1: 발급)
      */
-    public void issueCertificate(String certificateUrl) {
+    public void issueCertificate(String certificateObjectKey) {
         this.certificateStatus = 1;
-        this.certificateUrl = certificateUrl;
+        this.certificateObjectKey = certificateObjectKey;
     }
 }

--- a/src/test/java/org/forif_backend/application/user/UserServiceCertificateTest.java
+++ b/src/test/java/org/forif_backend/application/user/UserServiceCertificateTest.java
@@ -1,0 +1,75 @@
+package org.forif_backend.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.forif_backend.application.auth.RefreshTokenService;
+import org.forif_backend.application.file.dto.FileInfo;
+import org.forif_backend.application.file.port.out.FilePort;
+import org.forif_backend.application.semester.SemesterService;
+import org.forif_backend.application.user.dto.GetCertificateResult;
+import org.forif_backend.common.auth.JwtProvider;
+import org.forif_backend.domain.staff.StaffAccountRepository;
+import org.forif_backend.domain.study.StudyRepository;
+import org.forif_backend.domain.study.StudyUser;
+import org.forif_backend.domain.study.StudyUserRepository;
+import org.forif_backend.domain.user.GoogleOAuthClient;
+import org.forif_backend.domain.user.UserApplyRepository;
+import org.forif_backend.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceCertificateTest {
+
+    @Mock private SemesterService semesterService;
+    @Mock private UserRepository userRepository;
+    @Mock private UserApplyRepository userApplyRepository;
+    @Mock private StudyRepository studyRepository;
+    @Mock private StudyUserRepository studyUserRepository;
+    @Mock private StaffAccountRepository staffAccountRepository;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private GoogleOAuthClient googleOAuthClient;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private FilePort filePort;
+
+    @InjectMocks private UserService userService;
+
+    @Test
+    void generatesAFreshViewUrlFromTheStoredCertificateObjectKey() {
+        StudyUser studyUser = org.mockito.Mockito.mock(StudyUser.class);
+        String objectKey = "certificates/2026-1/1/100.png";
+        String viewUrl = "https://example.com/fresh-certificate-url";
+
+        when(studyUserRepository.findByUserIdAndStudyId(1L, 1)).thenReturn(Optional.of(studyUser));
+        when(studyUser.getCertificateStatus()).thenReturn(1);
+        when(studyUser.getCertificateObjectKey()).thenReturn(objectKey);
+        when(filePort.generatePresignedViewUrl(objectKey)).thenReturn(new FileInfo(objectKey, viewUrl));
+
+        GetCertificateResult result = userService.getCertificate(1L, 1);
+
+        assertThat(result.certificateUrl()).isEqualTo(viewUrl);
+        verify(filePort).generatePresignedViewUrl(objectKey);
+    }
+
+    @Test
+    void returnsLegacyStoredUrlWithoutTreatingItAsAnObjectKey() {
+        StudyUser studyUser = org.mockito.Mockito.mock(StudyUser.class);
+        String legacyUrl = "https://example.com/legacy-certificate-url";
+
+        when(studyUserRepository.findByUserIdAndStudyId(1L, 1)).thenReturn(Optional.of(studyUser));
+        when(studyUser.getCertificateStatus()).thenReturn(1);
+        when(studyUser.getCertificateObjectKey()).thenReturn(legacyUrl);
+
+        GetCertificateResult result = userService.getCertificate(1L, 1);
+
+        assertThat(result.certificateUrl()).isEqualTo(legacyUrl);
+        verify(filePort, never()).generatePresignedViewUrl(legacyUrl);
+    }
+}


### PR DESCRIPTION
## 수료증 다운로드 URL 만료 문제 수정

### 변경 사항

- 수료증 발급 시 Presigned URL 대신 S3 object key를 저장하도록 변경했습니다.
- 마이페이지 수료증 다운로드 요청 시 object key로 새 Presigned URL을 생성합니다.
- 어드민 수료증 발급 현황의 다운로드 링크도 조회 시점에 새로 생성합니다.
- 기존 DB에 저장된 URL 형식의 발급 이력은 호환을 위해 그대로 반환합니다.
- 기존 만료 URL은 object key가 없어 재발급이 필요합니다.

### 검증

- `UserServiceCertificateTest` 통과