### PR TITLE
Feature/for 138

### DIFF
--- a/src/main/java/org/forif_backend/application/semester/SemesterPhaseGuard.java
+++ b/src/main/java/org/forif_backend/application/semester/SemesterPhaseGuard.java
@@ -83,6 +83,42 @@ public class SemesterPhaseGuard {
     }
 
     /**
+     * 해당 단계의 시작 전까지만 허용한다. 일정이 없으면 기존 fail-open 정책을 따른다.
+     */
+    @Transactional(readOnly = true)
+    public void requireBeforeStart(SemesterPhase phase) {
+        SemesterInfo active = semesterService.getActive();
+        requireBeforeStart(phase, active.actYear(), active.actSemester());
+    }
+
+    @Transactional(readOnly = true)
+    public void requireBeforeStart(SemesterPhase phase, int actYear, int actSemester) {
+        Optional<SemesterSchedule> schedule =
+                semesterScheduleRepository.findByYearAndSemesterAndPhase(actYear, actSemester, phase);
+        if (schedule.isEmpty() || schedule.get().notStartedAt(LocalDateTime.now())) {
+            return;
+        }
+
+        SemesterSchedule window = schedule.get();
+        throw new ForifException(ErrorCode.SEMESTER_PHASE_CLOSED, List.of(new ApiErrorData(
+                phase.name(),
+                "%s 시작 전까지만 가능합니다. 시작 시각은 %s입니다.".formatted(
+                        phase.getLabel(),
+                        window.getStartsAt().format(DISPLAY)),
+                null
+        )));
+    }
+
+    /** 일정이 없으면 상시 허용으로 간주해 수정 가능 여부 응답에도 동일하게 반영한다. */
+    @Transactional(readOnly = true)
+    public boolean isBeforeStart(SemesterPhase phase, int actYear, int actSemester) {
+        return semesterScheduleRepository
+                .findByYearAndSemesterAndPhase(actYear, actSemester, phase)
+                .map(schedule -> schedule.notStartedAt(LocalDateTime.now()))
+                .orElse(true);
+    }
+
+    /**
      * 모집 시작 전에는 허용하되, 해당 모집 단계가 끝난 뒤에는 새 대상을 만들지 못하게 한다.
      * 일정이 없는 학기는 기존 fail-open 정책을 따른다.
      */

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -99,7 +99,11 @@ public class StudyService {
     public List<StudyApplicationDto> getMyStudyApplications(Long mentorId) {
         return studyRepository.findStudyApplicationsByMentorId(mentorId)
                 .stream()
-                .map(study -> StudyApplicationDto.from(study, canModifyStudyApplication(study)))
+                .map(study -> StudyApplicationDto.from(
+                        study,
+                        canModifyStudyApplication(study),
+                        canCancelStudyApplication(study)
+                ))
                 .toList();
     }
 
@@ -117,6 +121,7 @@ public class StudyService {
                 .studyStatus(study.getStudyStatus())
                 .rejectReason(study.getRejectReason())
                 .canModify(canModifyStudyApplication(study))
+                .canCancel(canCancelStudyApplication(study))
                 .build();
     }
 
@@ -684,7 +689,7 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         studyMentorAccess.requireMentorOfActiveSemester(study, userId);
-        semesterPhaseGuard.requireOpen(SemesterPhase.MENTOR_RECRUIT);
+        semesterPhaseGuard.requireBeforeStart(SemesterPhase.MENTEE_RECRUIT);
 
         if (rejectedOnly || study.getStudyStatus() == StudyStatus.REJECTED) {
             study.reApply();
@@ -697,6 +702,18 @@ public class StudyService {
     }
 
     private boolean canModifyStudyApplication(Study study) {
+        SemesterInfo active = semesterService.getActive();
+        return study.getStudyStatus() != StudyStatus.APPROVED
+                && study.getActYear() == active.actYear()
+                && study.getActSemester() == active.actSemester()
+                && semesterPhaseGuard.isBeforeStart(
+                SemesterPhase.MENTEE_RECRUIT,
+                study.getActYear(),
+                study.getActSemester()
+        );
+    }
+
+    private boolean canCancelStudyApplication(Study study) {
         SemesterInfo active = semesterService.getActive();
         return study.getStudyStatus() != StudyStatus.APPROVED
                 && study.getActYear() == active.actYear()

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -333,17 +333,14 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         studyMentorAccess.requireMentorOfActiveSemester(study, userId);
-        semesterPhaseGuard.requireOpen(SemesterPhase.MENTOR_RECRUIT);
-
         if (study.getStudyStatus() == StudyStatus.APPROVED) {
-            throw new ForifException(ErrorCode.BAD_REQUEST);
+            throw new ForifException(ErrorCode.STUDY_ALREADY_APPROVED);
         }
+        semesterPhaseGuard.requireOpen(SemesterPhase.MENTOR_RECRUIT);
 
         // 승인 전 스터디에는 지원서·수강생·출석이 없어야 정상이다. 있는데 조용히 지우면
         // 멘티 기록이 소리 없이 사라지므로, 취소를 막고 운영진 확인을 거치게 한다.
-        if (userApplyRepository.existsByStudyId(studyId)
-                || !studyUserRepository.findAllByStudyId(studyId).isEmpty()
-                || !studyAttendanceRepository.findAllByStudyId(studyId).isEmpty()) {
+        if (hasStudyApplicationCancellationDependencies(studyId)) {
             throw new ForifException(ErrorCode.STUDY_CANCEL_HAS_DEPENDENTS);
         }
 
@@ -689,13 +686,27 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         studyMentorAccess.requireMentorOfActiveSemester(study, userId);
+        StudyStatus studyStatus = study.getStudyStatus();
+
+        if (studyStatus == StudyStatus.APPROVED) {
+            throw new ForifException(ErrorCode.STUDY_ALREADY_APPROVED);
+        }
+        if (rejectedOnly && studyStatus != StudyStatus.REJECTED) {
+            throw new ForifException(ErrorCode.REAPPLY_ONLY_FOR_REJECTED);
+        }
+        if (studyStatus != StudyStatus.PENDING
+                && studyStatus != StudyStatus.RE_APPLIED
+                && studyStatus != StudyStatus.REJECTED) {
+            throw new ForifException(ErrorCode.BAD_REQUEST);
+        }
+
         semesterPhaseGuard.requireBeforeStart(SemesterPhase.MENTEE_RECRUIT);
 
-        if (rejectedOnly || study.getStudyStatus() == StudyStatus.REJECTED) {
+        if (studyStatus == StudyStatus.REJECTED) {
+            // 반려 건을 수정하면 재신청 상태가 되므로, 심사 창이 닫힌 뒤에는
+            // 처리할 수 없는 RE_APPLIED 신청서가 생기지 않게 재신청을 막는다.
+            semesterPhaseGuard.requireOpen(SemesterPhase.MENTOR_REVIEW);
             study.reApply();
-        } else if (study.getStudyStatus() != StudyStatus.PENDING
-                && study.getStudyStatus() != StudyStatus.RE_APPLIED) {
-            throw new ForifException(ErrorCode.BAD_REQUEST);
         }
 
         return study;
@@ -703,14 +714,26 @@ public class StudyService {
 
     private boolean canModifyStudyApplication(Study study) {
         SemesterInfo active = semesterService.getActive();
-        return study.getStudyStatus() != StudyStatus.APPROVED
-                && study.getActYear() == active.actYear()
-                && study.getActSemester() == active.actSemester()
-                && semesterPhaseGuard.isBeforeStart(
+        if (study.getActYear() != active.actYear()
+                || study.getActSemester() != active.actSemester()
+                || !semesterPhaseGuard.isBeforeStart(
                 SemesterPhase.MENTEE_RECRUIT,
                 study.getActYear(),
                 study.getActSemester()
-        );
+        )) {
+            return false;
+        }
+
+        if (study.getStudyStatus() == StudyStatus.REJECTED) {
+            return semesterPhaseGuard.isOpen(
+                    SemesterPhase.MENTOR_REVIEW,
+                    study.getActYear(),
+                    study.getActSemester()
+            );
+        }
+
+        return study.getStudyStatus() == StudyStatus.PENDING
+                || study.getStudyStatus() == StudyStatus.RE_APPLIED;
     }
 
     private boolean canCancelStudyApplication(Study study) {
@@ -722,7 +745,14 @@ public class StudyService {
                 SemesterPhase.MENTOR_RECRUIT,
                 study.getActYear(),
                 study.getActSemester()
-        );
+        )
+                && !hasStudyApplicationCancellationDependencies(study.getId());
+    }
+
+    private boolean hasStudyApplicationCancellationDependencies(Integer studyId) {
+        return userApplyRepository.existsByStudyId(studyId)
+                || !studyUserRepository.findAllByStudyId(studyId).isEmpty()
+                || !studyAttendanceRepository.findAllByStudyId(studyId).isEmpty();
     }
 
     /**

--- a/src/main/java/org/forif_backend/application/study/dto/AdminStudyDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/AdminStudyDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.forif_backend.domain.study.RecruitStatus;
 import org.forif_backend.domain.study.Study;
+import org.forif_backend.domain.study.StudyDifficulty;
 import org.forif_backend.domain.study.StudyStatus;
 
 import java.time.LocalDateTime;
@@ -22,6 +23,8 @@ public class AdminStudyDto {
     private final String oneLiner;
     private final long menteeCount;
     private final RecruitStatus recruitStatus;
+    private final Integer weekDay;
+    private final StudyDifficulty difficulty;
     private final StudyStatus studyStatus;
     private final String rejectReason;
     private final LocalDateTime createdAt;
@@ -36,6 +39,8 @@ public class AdminStudyDto {
                 .oneLiner(study.getOneLiner())
                 .menteeCount(menteeCount)
                 .recruitStatus(study.getRecruitStatus())
+                .weekDay(study.getWeekDay())
+                .difficulty(study.getDifficulty())
                 .studyStatus(study.getStudyStatus())
                 .rejectReason(study.getRejectReason())
                 .createdAt(study.getCreatedAt())

--- a/src/main/java/org/forif_backend/application/study/dto/AdminStudyDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/AdminStudyDto.java
@@ -28,6 +28,7 @@ public class AdminStudyDto {
     private final StudyStatus studyStatus;
     private final String rejectReason;
     private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public static AdminStudyDto of(Study study, long menteeCount) {
         return AdminStudyDto.builder()
@@ -44,6 +45,7 @@ public class AdminStudyDto {
                 .studyStatus(study.getStudyStatus())
                 .rejectReason(study.getRejectReason())
                 .createdAt(study.getCreatedAt())
+                .updatedAt(study.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/org/forif_backend/application/study/dto/StudyApplicationDetailDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyApplicationDetailDto.java
@@ -13,4 +13,5 @@ public class StudyApplicationDetailDto {
     private final StudyStatus studyStatus;
     private final String rejectReason;
     private final boolean canModify;
+    private final boolean canCancel;
 }

--- a/src/main/java/org/forif_backend/application/study/dto/StudyApplicationDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyApplicationDto.java
@@ -22,8 +22,9 @@ public class StudyApplicationDto {
     private final String rejectReason;
     private final LocalDateTime createdAt;
     private final boolean canModify;
+    private final boolean canCancel;
 
-    public static StudyApplicationDto from(Study study, boolean canModify) {
+    public static StudyApplicationDto from(Study study, boolean canModify, boolean canCancel) {
         return StudyApplicationDto.builder()
                 .id(study.getId())
                 .studyName(study.getStudyName())
@@ -33,6 +34,7 @@ public class StudyApplicationDto {
                 .rejectReason(study.getRejectReason())
                 .createdAt(study.getCreatedAt())
                 .canModify(canModify)
+                .canCancel(canCancel)
                 .build();
     }
 }

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -94,7 +94,7 @@ public enum ErrorCode {
     STUDY_CANCEL_HAS_DEPENDENTS(HttpStatus.BAD_REQUEST, "FOR130-400", "지원서나 수강 기록이 있는 스터디는 취소할 수 없습니다. 운영진에게 문의해주세요."),
     AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOR132-400", "자율스터디는 출석 체크 및 수료증 발급 대상이 아닙니다."),
     AUTONOMOUS_STUDY_NAME_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR133-400", "자율스터디의 이름은 변경할 수 없습니다."),
-    AUTONOMOUS_STUDY_NAME_RESERVED(HttpStatus.BAD_REQUEST, "FOR134-400", "자율스터디 명칭은 일반 스터디에 사용할 수 없습니다."),
+    AUTONOMOUS_STUDY_NAME_RESERVED(HttpStatus.BAD_REQUEST, "FOR137-400", "자율스터디 명칭은 일반 스터디에 사용할 수 없습니다."),
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR044-409", "이미 가입된 사용자입니다."),
@@ -105,6 +105,7 @@ public enum ErrorCode {
     HACKATHON_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR074-409", "이미 등록된 해커톤입니다."),
     HACKATHON_ACTIVE_EVENT_EXISTS(HttpStatus.CONFLICT, "FOR076-409", "진행 중인 해커톤이 있어 새 해커톤을 생성할 수 없습니다."),
     AUTONOMOUS_STUDY_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR131-409", "현재 학기에 자율스터디가 이미 개설되어 있습니다."),
+    STUDY_APPLICATION_UPDATE_CONFLICT(HttpStatus.CONFLICT, "FOR138-409", "스터디 신청서가 다른 요청으로 변경되었습니다. 새로고침 후 다시 시도해주세요."),
 
     // Product (서비스 쇼케이스)
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOR110-404", "해당 서비스를 찾을 수 없습니다."),

--- a/src/main/java/org/forif_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/forif_backend/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -31,6 +32,14 @@ public class GlobalExceptionHandler {
             response = ApiResponse.error(errorCode);
         }
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ApiResponse<?>> handleOptimisticLockingFailure(
+            ObjectOptimisticLockingFailureException e) {
+        log.warn("동시 수정 충돌: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.STUDY_APPLICATION_UPDATE_CONFLICT;
+        return new ResponseEntity<>(ApiResponse.error(errorCode), errorCode.getHttpStatus());
     }
 
     /**

--- a/src/main/java/org/forif_backend/domain/study/Study.java
+++ b/src/main/java/org/forif_backend/domain/study/Study.java
@@ -43,6 +43,11 @@ public class Study extends BaseTimeEntity {
     @Column(name = "study_id")
     private Integer id;
 
+    /** 신청서 수정과 승인 요청이 경합할 때 마지막 저장이 상태를 되돌리지 않도록 보호한다. */
+    @Version
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private Long version;
+
     @Column(nullable = false)
     private int actYear;
 

--- a/src/main/java/org/forif_backend/domain/study/Study.java
+++ b/src/main/java/org/forif_backend/domain/study/Study.java
@@ -112,7 +112,7 @@ public class Study extends BaseTimeEntity {
 
     private Boolean isOnline;
 
-    @Column(length = 500)
+    @Column(length = 3000)
     private String goal;
 
     @Column(length = 50)

--- a/src/main/java/org/forif_backend/web/study/StudyController.java
+++ b/src/main/java/org/forif_backend/web/study/StudyController.java
@@ -47,7 +47,7 @@ public class StudyController {
             @Parameter(description = "페이지 당 항목 수") @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "조회 연도 (예: 2025)") @RequestParam(required = false) Integer year,
             @Parameter(description = "조회 학기 (1 또는 2)") @RequestParam(required = false) Integer semester,
-            @Parameter(description = "난이도 필터 (BEGINNER, INTERMEDIATE, ADVANCED)") @RequestParam(required = false) List<StudyDifficulty> difficulties,
+            @Parameter(description = "난이도 필터 (EASY=쉬움, SEMI_EASY=조금 쉬움, NORMAL=보통, SEMI_HARD=조금 어려움, HARD=어려움)") @RequestParam(required = false) List<StudyDifficulty> difficulties,
             @Parameter(description = "태그 이름 필터 (복수 입력 가능)") @RequestParam(required = false) String[] tags,
             @Parameter(description = "모집 상태 필터 (OPEN=모집중, CLOSED=모집마감)") @RequestParam(value = "recruit_status", required = false) RecruitStatus recruitStatus,
             @Parameter(description = "스터디 이름 검색어") @RequestParam(required = false) String search) {

--- a/src/main/java/org/forif_backend/web/study/dto/AdminStudyResponse.java
+++ b/src/main/java/org/forif_backend/web/study/dto/AdminStudyResponse.java
@@ -15,6 +15,8 @@ public record AdminStudyResponse(
         String oneLiner,
         long menteeCount,
         String recruitStatus,
+        Integer weekDay,
+        String difficulty,
         String studyStatus,
         String rejectReason,
         LocalDateTime createdAt
@@ -32,6 +34,10 @@ public record AdminStudyResponse(
                 ? dto.getStudyStatus().getValue()
                 : null;
 
+        String difficultyValue = dto.getDifficulty() != null
+                ? dto.getDifficulty().getValue()
+                : null;
+
         return new AdminStudyResponse(
                 dto.getId(),
                 dto.getStudyName(),
@@ -41,6 +47,8 @@ public record AdminStudyResponse(
                 dto.getOneLiner(),
                 dto.getMenteeCount(),
                 recruitStatusValue,
+                dto.getWeekDay(),
+                difficultyValue,
                 studyStatusValue,
                 dto.getRejectReason(),
                 dto.getCreatedAt()

--- a/src/main/java/org/forif_backend/web/study/dto/AdminStudyResponse.java
+++ b/src/main/java/org/forif_backend/web/study/dto/AdminStudyResponse.java
@@ -19,7 +19,8 @@ public record AdminStudyResponse(
         String difficulty,
         String studyStatus,
         String rejectReason,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
     public static AdminStudyResponse from(AdminStudyDto dto) {
         List<String> tagNames = dto.getTags().stream()
@@ -51,7 +52,8 @@ public record AdminStudyResponse(
                 difficultyValue,
                 studyStatusValue,
                 dto.getRejectReason(),
-                dto.getCreatedAt()
+                dto.getCreatedAt(),
+                dto.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/org/forif_backend/web/study/dto/CreateStudyApplyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/CreateStudyApplyRequest.java
@@ -40,11 +40,11 @@ public class CreateStudyApplyRequest {
     }
 
     @NotBlank
-    @Length(min = 50, max = 500, message = "스터디 목표는 50자 이상 500자 이내로 작성해주세요.")
+    @Length(min = 50, max = 3000, message = "스터디 목표는 50자 이상 3000자 이내로 작성해주세요.")
     private String goal;                    // 스터디 목표
 
     @NotBlank
-    @Length(min = 50, max = 500, message = "스터디 소개는 50자 이상 500자 이내로 작성해주세요.")
+    @Length(min = 50, max = 3000, message = "스터디 소개는 50자 이상 3000자 이내로 작성해주세요.")
     private String explanation;             // 스터디 소개
 
     @NotNull

--- a/src/main/java/org/forif_backend/web/study/dto/StudyApplicationDetailResponse.java
+++ b/src/main/java/org/forif_backend/web/study/dto/StudyApplicationDetailResponse.java
@@ -7,19 +7,22 @@ public record StudyApplicationDetailResponse(
         StudyDetailResponse study,
         String studyStatus,
         String rejectReason,
-        boolean canModify
+        boolean canModify,
+        boolean canCancel
 ) {
     public static StudyApplicationDetailResponse from(
             StudyDetailDto study,
             StudyStatus studyStatus,
             String rejectReason,
-            boolean canModify
+            boolean canModify,
+            boolean canCancel
     ) {
         return new StudyApplicationDetailResponse(
                 StudyDetailResponse.from(study),
                 studyStatus.getValue(),
                 rejectReason,
-                canModify
+                canModify,
+                canCancel
         );
     }
 }

--- a/src/main/java/org/forif_backend/web/study/dto/StudyApplicationResponse.java
+++ b/src/main/java/org/forif_backend/web/study/dto/StudyApplicationResponse.java
@@ -13,7 +13,8 @@ public record StudyApplicationResponse(
         String studyStatus,
         String rejectReason,
         LocalDateTime createdAt,
-        boolean canModify
+        boolean canModify,
+        boolean canCancel
 ) {
     public static StudyApplicationResponse from(StudyApplicationDto dto) {
         return new StudyApplicationResponse(
@@ -24,7 +25,8 @@ public record StudyApplicationResponse(
                 dto.getStudyStatus().getValue(),
                 dto.getRejectReason(),
                 dto.getCreatedAt(),
-                dto.isCanModify()
+                dto.isCanModify(),
+                dto.isCanCancel()
         );
     }
 }

--- a/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
+++ b/src/main/java/org/forif_backend/web/study/dto/UpdateStudyRequest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import jakarta.validation.constraints.NotBlank;
 import org.forif_backend.domain.study.ReferenceType;
+import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,7 +22,10 @@ public class UpdateStudyRequest {
     @JsonAlias("title")
     private String studyName;
     private String oneLiner;
+    @Length(max = 3000, message = "스터디 소개는 최대 3000자 이내로 작성해주세요.")
     private String explanation;
+
+    @Length(max = 3000, message = "스터디 목표는 최대 3000자 이내로 작성해주세요.")
     private String goal;
 
     private String startTime;

--- a/src/main/java/org/forif_backend/web/studyApply/StudyApplyController.java
+++ b/src/main/java/org/forif_backend/web/studyApply/StudyApplyController.java
@@ -100,11 +100,12 @@ public class StudyApplyController {
                 application.getStudy(),
                 application.getStudyStatus(),
                 application.getRejectReason(),
-                application.isCanModify()
+                application.isCanModify(),
+                application.isCanCancel()
         )));
     }
 
-    @Operation(summary = "내 스터디 개설 신청 수정", description = "승인 전 본인 신청서의 변경한 항목만 수정할 수 있으며, 반려 건은 수정 후 재신청 상태로 전환됩니다.")
+    @Operation(summary = "내 스터디 개설 신청 수정", description = "멘티 모집 시작 전까지 승인 전 본인 신청서의 변경한 항목만 수정할 수 있으며, 반려 건은 수정 후 재신청 상태로 전환됩니다.")
     @PatchMapping(value = "/{studyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<CreateStudyApplyResponse>> updateStudyApplication(
             @PathVariable Integer studyId,

--- a/src/test/java/org/forif_backend/application/semester/SemesterPhaseGuardTest.java
+++ b/src/test/java/org/forif_backend/application/semester/SemesterPhaseGuardTest.java
@@ -54,4 +54,39 @@ class SemesterPhaseGuardTest {
                         ((ForifException) exception).getErrorCode())
                         .isEqualTo(ErrorCode.SEMESTER_PHASE_CLOSED));
     }
+
+    @Test
+    void allowsUpdatingAnApplicationBeforeMenteeRecruitmentStarts() {
+        when(scheduleRepository.findByYearAndSemesterAndPhase(2026, 2, SemesterPhase.MENTEE_RECRUIT))
+                .thenReturn(Optional.of(SemesterSchedule.create(
+                        2026,
+                        2,
+                        SemesterPhase.MENTEE_RECRUIT,
+                        LocalDateTime.now().plusDays(1),
+                        LocalDateTime.now().plusDays(7),
+                        1L
+                )));
+
+        assertThatCode(() -> guard.requireBeforeStart(SemesterPhase.MENTEE_RECRUIT, 2026, 2))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void blocksUpdatingAnApplicationWhenMenteeRecruitmentHasStarted() {
+        when(scheduleRepository.findByYearAndSemesterAndPhase(2026, 2, SemesterPhase.MENTEE_RECRUIT))
+                .thenReturn(Optional.of(SemesterSchedule.create(
+                        2026,
+                        2,
+                        SemesterPhase.MENTEE_RECRUIT,
+                        LocalDateTime.now().minusSeconds(1),
+                        LocalDateTime.now().plusDays(7),
+                        1L
+                )));
+
+        assertThatThrownBy(() -> guard.requireBeforeStart(SemesterPhase.MENTEE_RECRUIT, 2026, 2))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> org.assertj.core.api.Assertions.assertThat(
+                        ((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.SEMESTER_PHASE_CLOSED));
+    }
 }

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -145,6 +145,93 @@ class StudyServiceApplicationUpdateTest {
     }
 
     @Test
+    void doesNotExposeRejectedApplicationAsModifiableAfterMentorReviewEnds() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyApplicationsByMentorId(10L)).thenReturn(List.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.REJECTED);
+        when(study.getActYear()).thenReturn(2026);
+        when(study.getActSemester()).thenReturn(1);
+        when(study.getTags()).thenReturn(List.of());
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 1));
+        when(semesterPhaseGuard.isBeforeStart(
+                org.forif_backend.domain.semester.SemesterPhase.MENTEE_RECRUIT, 2026, 1))
+                .thenReturn(true);
+        when(semesterPhaseGuard.isOpen(
+                org.forif_backend.domain.semester.SemesterPhase.MENTOR_REVIEW, 2026, 1))
+                .thenReturn(false);
+
+        boolean canModify = studyService.getMyStudyApplications(10L).get(0).isCanModify();
+
+        assertThat(canModify).isFalse();
+    }
+
+    @Test
+    void blocksReapplyingRejectedApplicationAfterMentorReviewEnds() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.REJECTED);
+        doThrow(new ForifException(ErrorCode.SEMESTER_PHASE_CLOSED))
+                .when(semesterPhaseGuard)
+                .requireOpen(org.forif_backend.domain.semester.SemesterPhase.MENTOR_REVIEW);
+
+        assertThatThrownBy(() -> studyService.updateStudyApplication(
+                1, 10L, new UpdateStudyRequest(), null, null))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.SEMESTER_PHASE_CLOSED));
+
+        verify(study, never()).reApply();
+    }
+
+    @Test
+    void keepsApprovedApplicationBlockedDuringExtendedModificationPeriod() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.APPROVED);
+
+        assertThatThrownBy(() -> studyService.updateStudyApplication(
+                1, 10L, new UpdateStudyRequest(), null, null))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.STUDY_ALREADY_APPROVED));
+    }
+
+    @Test
+    void keepsApprovedApplicationCancellationBlockedBeforeCheckingPeriod() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyById(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.APPROVED);
+
+        assertThatThrownBy(() -> studyService.cancelStudyApplication(1, 10L))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.STUDY_ALREADY_APPROVED));
+
+        verify(semesterPhaseGuard, never())
+                .requireOpen(org.forif_backend.domain.semester.SemesterPhase.MENTOR_RECRUIT);
+    }
+
+    @Test
+    void doesNotExposeCancellationWhenApplicationHasDependents() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyApplicationsByMentorId(10L)).thenReturn(List.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
+        when(study.getActYear()).thenReturn(2026);
+        when(study.getActSemester()).thenReturn(1);
+        when(study.getTags()).thenReturn(List.of());
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 1));
+        when(semesterPhaseGuard.isOpen(
+                org.forif_backend.domain.semester.SemesterPhase.MENTOR_RECRUIT, 2026, 1))
+                .thenReturn(true);
+        when(userApplyRepository.existsByStudyId(0)).thenReturn(true);
+
+        boolean canCancel = studyService.getMyStudyApplications(10L).get(0).isCanCancel();
+
+        assertThat(canCancel).isFalse();
+        verify(userApplyRepository).existsByStudyId(0);
+    }
+
+    @Test
     void keepsExistingPlansWhenTheUpdateRequestOmitsStudyPlanList() {
         Study study = mock(Study.class);
         StudyTag tag = mock(StudyTag.class);
@@ -341,6 +428,7 @@ class StudyServiceApplicationUpdateTest {
 
         when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
         when(study.getPrimaryMentor()).thenReturn(primaryMentor);
+        when(study.getStudyStatus()).thenReturn(StudyStatus.REJECTED);
         when(primaryMentor.getId()).thenReturn(10L);
         when(study.getThumbnailImage()).thenReturn("studies/thumbnails/rejected.png");
         when(studyRepository.findStudyReferencesByStudyId(1)).thenReturn(List.of(existingFileReference));

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -102,7 +102,7 @@ class StudyServiceApplicationUpdateTest {
                 .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
                         .isEqualTo(ErrorCode.STUDY_NOT_IN_ACTIVE_SEMESTER));
 
-        verify(semesterPhaseGuard, never()).requireOpen(org.forif_backend.domain.semester.SemesterPhase.MENTOR_RECRUIT);
+        verify(semesterPhaseGuard, never()).requireBeforeStart(org.forif_backend.domain.semester.SemesterPhase.MENTEE_RECRUIT);
         verify(study, never()).reApply();
     }
 
@@ -118,8 +118,30 @@ class StudyServiceApplicationUpdateTest {
         boolean canModify = studyService.getMyStudyApplications(10L).get(0).isCanModify();
 
         assertThat(canModify).isFalse();
-        verify(semesterPhaseGuard, never()).isOpen(
-                org.forif_backend.domain.semester.SemesterPhase.MENTOR_RECRUIT, 2024, 2);
+        verify(semesterPhaseGuard, never()).isBeforeStart(
+                org.forif_backend.domain.semester.SemesterPhase.MENTEE_RECRUIT, 2024, 2);
+    }
+
+    @Test
+    void allowsModificationButNotCancellationBetweenRecruitmentPeriods() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyApplicationsByMentorId(10L)).thenReturn(List.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
+        when(study.getActYear()).thenReturn(2026);
+        when(study.getActSemester()).thenReturn(1);
+        when(study.getTags()).thenReturn(List.of());
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 1));
+        when(semesterPhaseGuard.isBeforeStart(
+                org.forif_backend.domain.semester.SemesterPhase.MENTEE_RECRUIT, 2026, 1))
+                .thenReturn(true);
+        when(semesterPhaseGuard.isOpen(
+                org.forif_backend.domain.semester.SemesterPhase.MENTOR_RECRUIT, 2026, 1))
+                .thenReturn(false);
+
+        var application = studyService.getMyStudyApplications(10L).get(0);
+
+        assertThat(application.isCanModify()).isTrue();
+        assertThat(application.isCanCancel()).isFalse();
     }
 
     @Test

--- a/src/test/java/org/forif_backend/application/study/StudyServiceCancelApplicationTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceCancelApplicationTest.java
@@ -102,7 +102,7 @@ class StudyServiceCancelApplicationTest {
 
         assertThatThrownBy(() -> studyService.cancelStudyApplication(STUDY_ID, MENTOR_ID))
                 .isInstanceOf(ForifException.class)
-                .extracting("errorCode").isEqualTo(ErrorCode.BAD_REQUEST);
+                .extracting("errorCode").isEqualTo(ErrorCode.STUDY_ALREADY_APPROVED);
         verify(studyRepository, never()).deleteStudyById(STUDY_ID);
     }
 


### PR DESCRIPTION
## 작업 내용

- 스터디 난이도 필터 API 설명을 5단계 난이도 용어로 정리
- 어드민 스터디 목록 응답에 `week_day`, `difficulty` 추가
- 스터디 상세소개/목표 최대 글자 수를 3,000자로 확장
  - `tb_study.goal` 컬럼은 배포 전 `VARCHAR(3000)`으로 변경 필요
- 스터디 개설 신청서 권한 분리
  - 수정·재신청: 멘티 모집 시작 전까지 가능
  - 취소: 기존대로 멘토 모집 기간에만 가능
  - 응답에 `can_cancel` 추가

## 테스트

- `SemesterPhaseGuardTest`
- `StudyServiceApplicationUpdateTest`