### PR TITLE
feat(study): 승인 신청서 수정 기간 및 조회 정책 개선

### DIFF
--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -97,7 +97,12 @@ public class StudyService {
 
     @Transactional(readOnly = true)
     public List<StudyApplicationDto> getMyStudyApplications(Long mentorId) {
-        return studyRepository.findStudyApplicationsByMentorId(mentorId)
+        SemesterInfo activeSemester = semesterService.getActive();
+        return studyRepository.findStudyApplicationsByMentorId(
+                        mentorId,
+                        activeSemester.actYear(),
+                        activeSemester.actSemester()
+                )
                 .stream()
                 .map(study -> StudyApplicationDto.from(
                         study,
@@ -112,7 +117,11 @@ public class StudyService {
         Study study = studyRepository.findStudyByIdWithTags(studyId)
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
-        if (!study.isMentor(mentorId) || study.getStudyStatus() == StudyStatus.APPROVED) {
+        SemesterInfo activeSemester = semesterService.getActive();
+        boolean isApprovedOutsideActiveSemester = study.getStudyStatus() == StudyStatus.APPROVED
+                && (study.getActYear() != activeSemester.actYear()
+                || study.getActSemester() != activeSemester.actSemester());
+        if (!study.isMentor(mentorId) || isApprovedOutsideActiveSemester) {
             throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
         }
 
@@ -688,15 +697,13 @@ public class StudyService {
         studyMentorAccess.requireMentorOfActiveSemester(study, userId);
         StudyStatus studyStatus = study.getStudyStatus();
 
-        if (studyStatus == StudyStatus.APPROVED) {
-            throw new ForifException(ErrorCode.STUDY_ALREADY_APPROVED);
-        }
         if (rejectedOnly && studyStatus != StudyStatus.REJECTED) {
             throw new ForifException(ErrorCode.REAPPLY_ONLY_FOR_REJECTED);
         }
         if (studyStatus != StudyStatus.PENDING
                 && studyStatus != StudyStatus.RE_APPLIED
-                && studyStatus != StudyStatus.REJECTED) {
+                && studyStatus != StudyStatus.REJECTED
+                && studyStatus != StudyStatus.APPROVED) {
             throw new ForifException(ErrorCode.BAD_REQUEST);
         }
 
@@ -733,7 +740,8 @@ public class StudyService {
         }
 
         return study.getStudyStatus() == StudyStatus.PENDING
-                || study.getStudyStatus() == StudyStatus.RE_APPLIED;
+                || study.getStudyStatus() == StudyStatus.RE_APPLIED
+                || study.getStudyStatus() == StudyStatus.APPROVED;
     }
 
     private boolean canCancelStudyApplication(Study study) {

--- a/src/main/java/org/forif_backend/application/study/StudyService.java
+++ b/src/main/java/org/forif_backend/application/study/StudyService.java
@@ -104,6 +104,7 @@ public class StudyService {
                         activeSemester.actSemester()
                 )
                 .stream()
+                .filter(study -> !study.isAutonomousStudy())
                 .map(study -> StudyApplicationDto.from(
                         study,
                         canModifyStudyApplication(study),
@@ -121,7 +122,9 @@ public class StudyService {
         boolean isApprovedOutsideActiveSemester = study.getStudyStatus() == StudyStatus.APPROVED
                 && (study.getActYear() != activeSemester.actYear()
                 || study.getActSemester() != activeSemester.actSemester());
-        if (!study.isMentor(mentorId) || isApprovedOutsideActiveSemester) {
+        if (!study.isMentor(mentorId)
+                || study.isAutonomousStudy()
+                || isApprovedOutsideActiveSemester) {
             throw new ForifException(ErrorCode.INSUFFICIENT_PERMISSION);
         }
 
@@ -695,6 +698,9 @@ public class StudyService {
                 .orElseThrow(() -> new ForifException(ErrorCode.STUDY_NOT_FOUND));
 
         studyMentorAccess.requireMentorOfActiveSemester(study, userId);
+        if (study.isAutonomousStudy()) {
+            throw new ForifException(ErrorCode.AUTONOMOUS_STUDY_APPLICATION_NOT_ALLOWED);
+        }
         StudyStatus studyStatus = study.getStudyStatus();
 
         if (rejectedOnly && studyStatus != StudyStatus.REJECTED) {
@@ -720,6 +726,10 @@ public class StudyService {
     }
 
     private boolean canModifyStudyApplication(Study study) {
+        if (study.isAutonomousStudy()) {
+            return false;
+        }
+
         SemesterInfo active = semesterService.getActive();
         if (study.getActYear() != active.actYear()
                 || study.getActSemester() != active.actSemester()

--- a/src/main/java/org/forif_backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/forif_backend/common/exception/ErrorCode.java
@@ -95,6 +95,7 @@ public enum ErrorCode {
     AUTONOMOUS_STUDY_OPERATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOR132-400", "자율스터디는 출석 체크 및 수료증 발급 대상이 아닙니다."),
     AUTONOMOUS_STUDY_NAME_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "FOR133-400", "자율스터디의 이름은 변경할 수 없습니다."),
     AUTONOMOUS_STUDY_NAME_RESERVED(HttpStatus.BAD_REQUEST, "FOR137-400", "자율스터디 명칭은 일반 스터디에 사용할 수 없습니다."),
+    AUTONOMOUS_STUDY_APPLICATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOR139-400", "자율스터디는 개설 신청서 조회 및 수정 대상이 아닙니다."),
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "FOR044-409", "이미 가입된 사용자입니다."),

--- a/src/main/java/org/forif_backend/domain/study/StudyRepository.java
+++ b/src/main/java/org/forif_backend/domain/study/StudyRepository.java
@@ -153,5 +153,5 @@ public interface StudyRepository {
      * @return 스터디 리스트
      */
     List<Study> findStudiesByMentorId(Long mentorId);
-    List<Study> findStudyApplicationsByMentorId(Long mentorId);
+    List<Study> findStudyApplicationsByMentorId(Long mentorId, int actYear, int actSemester);
 }

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
@@ -549,7 +549,7 @@ public class StudyQueryRepository {
                 .fetch();
     }
 
-    public List<Study> findStudyApplicationsByMentorId(Long mentorId) {
+    public List<Study> findStudyApplicationsByMentorId(Long mentorId, int actYear, int actSemester) {
         return queryFactory
                 .selectFrom(study).distinct()
                 .leftJoin(study.tags, studyTag).fetchJoin()
@@ -558,10 +558,13 @@ public class StudyQueryRepository {
                         study.primaryMentor.id.eq(mentorId)
                                 .or(secondaryMentor.id.eq(mentorId)),
                         study.studyStatus.in(
-                                StudyStatus.PENDING,
-                                StudyStatus.RE_APPLIED,
-                                StudyStatus.REJECTED
-                        )
+                                        StudyStatus.PENDING,
+                                        StudyStatus.RE_APPLIED,
+                                        StudyStatus.REJECTED
+                                )
+                                .or(study.studyStatus.eq(StudyStatus.APPROVED)
+                                        .and(study.actYear.eq(actYear))
+                                        .and(study.actSemester.eq(actSemester)))
                 )
                 .orderBy(study.createdAt.desc())
                 .fetch();

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepository.java
@@ -557,6 +557,7 @@ public class StudyQueryRepository {
                 .where(
                         study.primaryMentor.id.eq(mentorId)
                                 .or(secondaryMentor.id.eq(mentorId)),
+                        study.autonomousFlag.isNull().or(study.autonomousFlag.isFalse()),
                         study.studyStatus.in(
                                         StudyStatus.PENDING,
                                         StudyStatus.RE_APPLIED,

--- a/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
+++ b/src/main/java/org/forif_backend/infrastructure/persistence/study/StudyRepositoryImpl.java
@@ -261,8 +261,8 @@ public class StudyRepositoryImpl implements StudyRepository {
     }
 
     @Override
-    public List<Study> findStudyApplicationsByMentorId(Long mentorId) {
-        return studyQueryRepository.findStudyApplicationsByMentorId(mentorId);
+    public List<Study> findStudyApplicationsByMentorId(Long mentorId, int actYear, int actSemester) {
+        return studyQueryRepository.findStudyApplicationsByMentorId(mentorId, actYear, actSemester);
     }
 
 }

--- a/src/main/java/org/forif_backend/web/studyApply/StudyApplyController.java
+++ b/src/main/java/org/forif_backend/web/studyApply/StudyApplyController.java
@@ -77,7 +77,7 @@ public class StudyApplyController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    @Operation(summary = "내 스터디 개설 신청 목록 조회", description = "승인 전 또는 반려된 본인의 스터디 개설 신청서를 조회합니다.")
+    @Operation(summary = "내 스터디 개설 신청 목록 조회", description = "승인 전 또는 반려된 신청서와 현재 활동 학기에 승인된 본인의 스터디 개설 신청서를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<StudyApplicationResponse>>> getMyStudyApplications(
             @AuthenticationPrincipal Long userId
@@ -89,7 +89,7 @@ public class StudyApplyController {
         return ResponseEntity.ok(ApiResponse.success(applications));
     }
 
-    @Operation(summary = "내 스터디 개설 신청 상세 조회", description = "본인이 개설한 승인 전 또는 반려된 신청서만 조회할 수 있습니다.")
+    @Operation(summary = "내 스터디 개설 신청 상세 조회", description = "본인이 개설한 승인 전·반려 신청서와 현재 활동 학기에 승인된 신청서를 조회할 수 있습니다.")
     @GetMapping("/{studyId}")
     public ResponseEntity<ApiResponse<StudyApplicationDetailResponse>> getMyStudyApplication(
             @PathVariable Integer studyId,
@@ -105,7 +105,7 @@ public class StudyApplyController {
         )));
     }
 
-    @Operation(summary = "내 스터디 개설 신청 수정", description = "멘티 모집 시작 전까지 승인 전 본인 신청서의 변경한 항목만 수정할 수 있으며, 반려 건은 수정 후 재신청 상태로 전환됩니다.")
+    @Operation(summary = "내 스터디 개설 신청 수정", description = "멘티 모집 시작 전까지 본인 신청서의 변경한 항목만 수정할 수 있습니다. 반려 건은 심사 기간 내에만 수정할 수 있으며, 수정 후 재신청 상태로 전환됩니다.")
     @PatchMapping(value = "/{studyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<CreateStudyApplyResponse>> updateStudyApplication(
             @PathVariable Integer studyId,

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -197,6 +197,102 @@ class StudyServiceApplicationUpdateTest {
     }
 
     @Test
+    void allowsUpdatingApprovedApplicationOperationalFields() {
+        Study study = mock(Study.class);
+        StudyTag tag = mock(StudyTag.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setExplanation("수정된 상세 소개입니다.");
+        request.setDifficulty(2);
+        request.setStartTime("19:00");
+        request.setStudyTagNames(List.of("backend"));
+        request.setStudyPlanList(List.of());
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.APPROVED);
+        when(studyRepository.findAllStudyTagByName(List.of("backend"))).thenReturn(List.of(tag));
+
+        studyService.updateStudyApplication(1, 10L, request, null, null);
+
+        verify(study).setExplanation("수정된 상세 소개입니다.");
+        verify(study).setStartTime("19:00");
+        verify(study).setTags(List.of(tag));
+        verify(studyRepository).deleteStudyPlansByStudyId(1);
+    }
+
+    @Test
+    void allowsUpdatingTheSecondaryMentorAndThumbnailAfterApproval() {
+        Study study = mock(Study.class);
+        User primaryMentor = mock(User.class);
+        User secondaryMentor = mock(User.class);
+        MultipartFile thumbnail = mock(MultipartFile.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setSecondaryMentorId(20L);
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.APPROVED);
+        when(study.getPrimaryMentor()).thenReturn(primaryMentor);
+        when(primaryMentor.getId()).thenReturn(10L);
+        when(userRepository.findUserById(20L)).thenReturn(Optional.of(secondaryMentor));
+        when(secondaryMentor.getUserName()).thenReturn("부멘토");
+        when(thumbnail.isEmpty()).thenReturn(false);
+        when(filePort.uploadFile(thumbnail)).thenReturn("studies/thumbnails/new.png");
+        when(filePort.generatePresignedViewUrl("studies/thumbnails/new.png"))
+                .thenReturn(new FileInfo("studies/thumbnails/new.png", "https://example.com/new.png"));
+
+        studyService.updateStudyApplication(1, 10L, request, thumbnail, null);
+
+        verify(study).setSecondaryMentor(secondaryMentor);
+        verify(study).setSecondaryMentorName("부멘토");
+        verify(study).setThumbnailImage("studies/thumbnails/new.png");
+    }
+
+    @Test
+    void allowsChangingAllApplicationFieldsAfterApprovalExceptPrimaryMentor() {
+        Study study = mock(Study.class);
+        UpdateStudyRequest request = new UpdateStudyRequest();
+        request.setStudyName("수정된 스터디명");
+        request.setOneLiner("수정된 한 줄 소개");
+        request.setGoal("수정된 목표");
+        request.setCapacity(20);
+        request.setSelectionCriteria("수정된 선발 기준");
+        request.setReferences(List.of());
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.APPROVED);
+
+        studyService.updateStudyApplication(1, 10L, request, null, List.of());
+
+        verify(study).setStudyName("수정된 스터디명");
+        verify(study).setOneLiner("수정된 한 줄 소개");
+        verify(study).setGoal("수정된 목표");
+        verify(study).setCapacity(20);
+        verify(study).setSelectionCriteria("수정된 선발 기준");
+        verify(studyRepository).findStudyReferencesByStudyId(1);
+    }
+
+    @Test
+    void excludesAutonomousStudiesFromApplicationEndpoints() {
+        Study study = mock(Study.class);
+        when(study.isAutonomousStudy()).thenReturn(true);
+        when(studyRepository.findStudyApplicationsByMentorId(10L, 2026, 1)).thenReturn(List.of(study));
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 1));
+
+        assertThat(studyService.getMyStudyApplications(10L)).isEmpty();
+
+        when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
+        when(study.isMentor(10L)).thenReturn(true);
+        assertThatThrownBy(() -> studyService.getMyStudyApplication(10L, 1))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.INSUFFICIENT_PERMISSION));
+
+        assertThatThrownBy(() -> studyService.updateStudyApplication(1, 10L, new UpdateStudyRequest(), null, null))
+                .isInstanceOf(ForifException.class)
+                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTONOMOUS_STUDY_APPLICATION_NOT_ALLOWED));
+    }
+
+    @Test
     void keepsApprovedApplicationCancellationBlockedBeforeCheckingPeriod() {
         Study study = mock(Study.class);
         when(studyRepository.findStudyById(1)).thenReturn(Optional.of(study));

--- a/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
+++ b/src/test/java/org/forif_backend/application/study/StudyServiceApplicationUpdateTest.java
@@ -109,7 +109,7 @@ class StudyServiceApplicationUpdateTest {
     @Test
     void marksPastSemesterApplicationsAsNotModifiable() {
         Study study = mock(Study.class);
-        when(studyRepository.findStudyApplicationsByMentorId(10L)).thenReturn(List.of(study));
+        when(studyRepository.findStudyApplicationsByMentorId(10L, 2026, 1)).thenReturn(List.of(study));
         when(study.getStudyStatus()).thenReturn(StudyStatus.REJECTED);
         when(study.getActYear()).thenReturn(2024);
         when(study.getTags()).thenReturn(List.of());
@@ -125,7 +125,7 @@ class StudyServiceApplicationUpdateTest {
     @Test
     void allowsModificationButNotCancellationBetweenRecruitmentPeriods() {
         Study study = mock(Study.class);
-        when(studyRepository.findStudyApplicationsByMentorId(10L)).thenReturn(List.of(study));
+        when(studyRepository.findStudyApplicationsByMentorId(10L, 2026, 1)).thenReturn(List.of(study));
         when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
         when(study.getActYear()).thenReturn(2026);
         when(study.getActSemester()).thenReturn(1);
@@ -147,7 +147,7 @@ class StudyServiceApplicationUpdateTest {
     @Test
     void doesNotExposeRejectedApplicationAsModifiableAfterMentorReviewEnds() {
         Study study = mock(Study.class);
-        when(studyRepository.findStudyApplicationsByMentorId(10L)).thenReturn(List.of(study));
+        when(studyRepository.findStudyApplicationsByMentorId(10L, 2026, 1)).thenReturn(List.of(study));
         when(study.getStudyStatus()).thenReturn(StudyStatus.REJECTED);
         when(study.getActYear()).thenReturn(2026);
         when(study.getActSemester()).thenReturn(1);
@@ -184,16 +184,16 @@ class StudyServiceApplicationUpdateTest {
     }
 
     @Test
-    void keepsApprovedApplicationBlockedDuringExtendedModificationPeriod() {
+    void allowsApprovedApplicationModificationBeforeMenteeRecruitmentStarts() {
         Study study = mock(Study.class);
         when(studyRepository.findStudyByIdWithTags(1)).thenReturn(Optional.of(study));
         when(study.getStudyStatus()).thenReturn(StudyStatus.APPROVED);
 
-        assertThatThrownBy(() -> studyService.updateStudyApplication(
-                1, 10L, new UpdateStudyRequest(), null, null))
-                .isInstanceOf(ForifException.class)
-                .satisfies(exception -> assertThat(((ForifException) exception).getErrorCode())
-                        .isEqualTo(ErrorCode.STUDY_ALREADY_APPROVED));
+        studyService.updateStudyApplication(1, 10L, new UpdateStudyRequest(), null, null);
+
+        verify(semesterPhaseGuard).requireBeforeStart(
+                org.forif_backend.domain.semester.SemesterPhase.MENTEE_RECRUIT);
+        verify(study, never()).reApply();
     }
 
     @Test
@@ -214,7 +214,7 @@ class StudyServiceApplicationUpdateTest {
     @Test
     void doesNotExposeCancellationWhenApplicationHasDependents() {
         Study study = mock(Study.class);
-        when(studyRepository.findStudyApplicationsByMentorId(10L)).thenReturn(List.of(study));
+        when(studyRepository.findStudyApplicationsByMentorId(10L, 2026, 1)).thenReturn(List.of(study));
         when(study.getStudyStatus()).thenReturn(StudyStatus.PENDING);
         when(study.getActYear()).thenReturn(2026);
         when(study.getActSemester()).thenReturn(1);
@@ -229,6 +229,25 @@ class StudyServiceApplicationUpdateTest {
 
         assertThat(canCancel).isFalse();
         verify(userApplyRepository).existsByStudyId(0);
+    }
+
+    @Test
+    void exposesCurrentSemesterApprovedApplicationAsModifiableBeforeMenteeRecruitmentStarts() {
+        Study study = mock(Study.class);
+        when(studyRepository.findStudyApplicationsByMentorId(10L, 2026, 1)).thenReturn(List.of(study));
+        when(study.getStudyStatus()).thenReturn(StudyStatus.APPROVED);
+        when(study.getActYear()).thenReturn(2026);
+        when(study.getActSemester()).thenReturn(1);
+        when(study.getTags()).thenReturn(List.of());
+        when(semesterService.getActive()).thenReturn(SemesterInfo.of(2026, 1));
+        when(semesterPhaseGuard.isBeforeStart(
+                org.forif_backend.domain.semester.SemesterPhase.MENTEE_RECRUIT, 2026, 1))
+                .thenReturn(true);
+
+        var application = studyService.getMyStudyApplications(10L).get(0);
+
+        assertThat(application.isCanModify()).isTrue();
+        assertThat(application.isCanCancel()).isFalse();
     }
 
     @Test

--- a/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepositoryMentorTest.java
+++ b/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepositoryMentorTest.java
@@ -89,6 +89,8 @@ class StudyQueryRepositoryMentorTest {
         Study currentApproved = persistApprovedStudy(mentor, YEAR, SEMESTER, "현재 학기 승인 스터디");
         Study pastApproved = persistApprovedStudy(mentor, 2025, 2, "지난 학기 승인 스터디");
         Study rejected = persistRejectedStudy(mentor, null, "반려 신청서");
+        Study autonomous = Study.createAutonomousStudy(mentor, YEAR, SEMESTER);
+        entityManager.persist(autonomous);
         entityManager.flush();
         entityManager.clear();
 
@@ -98,7 +100,7 @@ class StudyQueryRepositoryMentorTest {
         assertThat(applications)
                 .extracting(Study::getId)
                 .contains(currentApproved.getId(), rejected.getId())
-                .doesNotContain(pastApproved.getId());
+                .doesNotContain(pastApproved.getId(), autonomous.getId());
     }
 
     private User persistUser(Long id, String name) {

--- a/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepositoryMentorTest.java
+++ b/src/test/java/org/forif_backend/infrastructure/persistence/study/StudyQueryRepositoryMentorTest.java
@@ -83,17 +83,40 @@ class StudyQueryRepositoryMentorTest {
         assertThat(studyNames).containsExactly(Map.entry(approvedMentor.getId(), "운영체제 심화 스터디"));
     }
 
+    @Test
+    void returnsCurrentSemesterApprovedApplicationsButExcludesPastApprovedApplications() {
+        User mentor = persistUser(900004L, "신청 멘토");
+        Study currentApproved = persistApprovedStudy(mentor, YEAR, SEMESTER, "현재 학기 승인 스터디");
+        Study pastApproved = persistApprovedStudy(mentor, 2025, 2, "지난 학기 승인 스터디");
+        Study rejected = persistRejectedStudy(mentor, null, "반려 신청서");
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Study> applications = studyQueryRepository.findStudyApplicationsByMentorId(
+                mentor.getId(), YEAR, SEMESTER);
+
+        assertThat(applications)
+                .extracting(Study::getId)
+                .contains(currentApproved.getId(), rejected.getId())
+                .doesNotContain(pastApproved.getId());
+    }
+
     private User persistUser(Long id, String name) {
         User user = User.createUser(id, name, id + "@forif.org", "010-0000-0000", "컴퓨터공학과");
         entityManager.persist(user);
         return user;
     }
 
-    private void persistApprovedStudy(User mentor, String name) {
-        Study study = Study.createPendingStudy(mentor, YEAR, SEMESTER);
+    private Study persistApprovedStudy(User mentor, String name) {
+        return persistApprovedStudy(mentor, YEAR, SEMESTER, name);
+    }
+
+    private Study persistApprovedStudy(User mentor, int year, int semester, String name) {
+        Study study = Study.createPendingStudy(mentor, year, semester);
         study.setStudyName(name);
         study.approve();
         entityManager.persist(study);
+        return study;
     }
 
     private void persistPendingStudy(User mentor, String name) {
@@ -102,12 +125,15 @@ class StudyQueryRepositoryMentorTest {
         entityManager.persist(study);
     }
 
-    private void persistRejectedStudy(User primaryMentor, User secondaryMentor, String name) {
+    private Study persistRejectedStudy(User primaryMentor, User secondaryMentor, String name) {
         Study study = Study.createPendingStudy(primaryMentor, YEAR, SEMESTER);
         study.setStudyName(name);
-        study.setSecondaryMentor(secondaryMentor);
-        study.setSecondaryMentorName(secondaryMentor.getUserName());
+        if (secondaryMentor != null) {
+            study.setSecondaryMentor(secondaryMentor);
+            study.setSecondaryMentorName(secondaryMentor.getUserName());
+        }
         study.reject("반려 사유");
         entityManager.persist(study);
+        return study;
     }
 }


### PR DESCRIPTION
## 개요

승인된 스터디 개설 신청서를 현재 활동 학기 동안 멘토의 신청서 목록에서 계속 조회할 수 있도록 개선했습니다.

## 변경 사항

- 현재 활동 학기의 `APPROVED` 신청서를 목록·상세 조회에 포함
- 승인 건도 멘티 모집 시작 전까지 수정 가능하도록 허용
- 승인 건 취소는 기존대로 불가
- 반려 건은 심사 기간 내에만 수정·재신청 가능하도록 유지해 심사 종료 후 미처리 재신청이 생성되지 않도록 처리
- 신청서 조회·수정 API 설명 갱신
- 승인 건 조회/수정 가능 여부 및 과거 학기 승인 건 제외 테스트 추가

## 테스트

- `StudyServiceApplicationUpdateTest`
- `StudyQueryRepositoryMentorTest`