### PR TITLE
feat: 스터디 참고자료 파일명 응답 추가

### DIFF
--- a/src/main/java/org/forif_backend/application/study/dto/StudyReferenceDto.java
+++ b/src/main/java/org/forif_backend/application/study/dto/StudyReferenceDto.java
@@ -15,6 +15,7 @@ public class StudyReferenceDto {
     private final UUID id;
     private final ReferenceType referenceType;
     private final String content;
+    private final String fileName;
 
     public static StudyReferenceDto from(StudyReference reference) {
         return from(reference, reference.getContent());
@@ -25,6 +26,36 @@ public class StudyReferenceDto {
                 .id(reference.getId())
                 .referenceType(reference.getReferenceType())
                 .content(content)
+                .fileName(resolveFileName(reference))
                 .build();
+    }
+
+    private static String resolveFileName(StudyReference reference) {
+        if (reference.getReferenceType() != ReferenceType.FILE) {
+            return null;
+        }
+
+        String objectKey = reference.getContent();
+        if (objectKey == null || objectKey.isBlank()) {
+            return null;
+        }
+
+        String fileName = objectKey.substring(objectKey.lastIndexOf('/') + 1);
+        int queryIndex = fileName.indexOf('?');
+        if (queryIndex >= 0) {
+            fileName = fileName.substring(0, queryIndex);
+        }
+
+        // 저장소 객체 키는 "UUID-원본파일명" 형식이다. 사용자에게는 원본 파일명만 노출한다.
+        if (fileName.length() > 37 && fileName.charAt(36) == '-') {
+            try {
+                UUID.fromString(fileName.substring(0, 36));
+                return fileName.substring(37);
+            } catch (IllegalArgumentException ignored) {
+                // UUID 접두사가 아닌 기존 객체 키는 그대로 사용한다.
+            }
+        }
+
+        return fileName;
     }
 }

--- a/src/main/java/org/forif_backend/web/study/dto/StudyDetailResponse.java
+++ b/src/main/java/org/forif_backend/web/study/dto/StudyDetailResponse.java
@@ -54,10 +54,16 @@ public record StudyDetailResponse(
     public record ReferenceResponse(
             UUID id,
             String referenceType,
-            String content
+            String content,
+            String fileName
     ) {
         public static ReferenceResponse from(StudyReferenceDto dto) {
-            return new ReferenceResponse(dto.getId(), dto.getReferenceType().name(), dto.getContent());
+            return new ReferenceResponse(
+                    dto.getId(),
+                    dto.getReferenceType().name(),
+                    dto.getContent(),
+                    dto.getFileName()
+            );
         }
     }
 

--- a/src/test/java/org/forif_backend/application/study/dto/StudyReferenceDtoTest.java
+++ b/src/test/java/org/forif_backend/application/study/dto/StudyReferenceDtoTest.java
@@ -1,0 +1,36 @@
+package org.forif_backend.application.study.dto;
+
+import org.forif_backend.domain.study.ReferenceType;
+import org.forif_backend.domain.study.StudyReference;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StudyReferenceDtoTest {
+
+    @Test
+    void exposesTheOriginalFileNameWithoutTheStorageUuidPrefix() {
+        StudyReference reference = StudyReference.create(
+                null,
+                ReferenceType.FILE,
+                "studies/references/123e4567-e89b-12d3-a456-426614174000-study-guide.pdf"
+        );
+
+        StudyReferenceDto dto = StudyReferenceDto.from(reference);
+
+        assertThat(dto.getFileName()).isEqualTo("study-guide.pdf");
+    }
+
+    @Test
+    void doesNotExposeAFileNameForUrlReferences() {
+        StudyReference reference = StudyReference.create(
+                null,
+                ReferenceType.URL,
+                "https://example.com/reference"
+        );
+
+        StudyReferenceDto dto = StudyReferenceDto.from(reference);
+
+        assertThat(dto.getFileName()).isNull();
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 스터디 상세의 FILE 참고자료 응답에 `file_name` 필드를 추가했습니다.
- 저장소 객체 키의 UUID 접두사를 제거해 사용자에게 원본 파일명을 제공합니다.
- URL 참고자료의 `file_name`은 `null`로 유지합니다.
- 기존 `content` 응답 및 파일 다운로드 흐름은 변경하지 않았습니다.

## 검증

- `gradlew.bat test --tests org.forif_backend.application.study.dto.StudyReferenceDtoTest`